### PR TITLE
add 500 font-weight

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -61,6 +61,12 @@ export const hpe = deepFreeze({
 
         @font-face {
           font-family: "Metric";
+          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Medium.woff") format('woff');
+          font-weight: 500;
+        }
+
+        @font-face {
+          font-family: "Metric";
           src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Light.woff") format('woff');
           font-weight: 100;
         }


### PR DESCRIPTION
Signed-off-by: Matt Glissmann mdglissmann@gmail.com

**What does this PR do?**
Adds 'MetricHPE-Web-Medium' at weight '500' to theme.

**Testing Performed**

- Applied build of this branch to local project which used `<Text weight={500} > ... </Text>`
- Confirmed Metric Medium font was sourced in network requests and applied correctly in render. Screenshot below:
![Screen Shot 2019-12-05 at 9 18 28 AM](https://user-images.githubusercontent.com/1756948/70262565-d0238500-1751-11ea-973a-c1bb19264e74.png)
