### PR TITLE
Update from design-system as of 3/12/20

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -101,8 +101,11 @@ export const hpe = deepFreeze({
       'graph-0': 'orange',
       'graph-1': 'blue',
       'graph-2': 'purple',
-      focus: 'green',
+      focus: 'teal!',
       placeholder: 'text-weak',
+      input: {
+        weight: 500,
+      },
     },
     font: {
       family: "'Metric', Arial, sans-serif",
@@ -161,11 +164,11 @@ export const hpe = deepFreeze({
     },
   },
   anchor: {
-    color: 'text',
-    fontWeight: 700,
+    color: 'brand',
     textDecoration: 'none',
+    fontWeight: 500,
     hover: {
-      textDecoration: 'none',
+      textDecoration: 'underline',
     },
   },
   button: {
@@ -225,10 +228,46 @@ export const hpe = deepFreeze({
   checkBox: {
     gap: 'medium',
     color: 'text-strong',
+    toggle: {
+      color: {
+        dark: global.colors['text-strong'].dark,
+        light: global.colors['text-strong'].dark,
+      },
+      background: 'background-back',
+    },
   },
   formField: {
     border: {
       side: 'all',
+    },
+    error: {
+      size: 'xsmall',
+      color: 'text-xweak',
+      margin: {
+        start: 'none',
+      },
+    },
+    help: {
+      size: 'xsmall',
+      color: 'text-xweak',
+      margin: {
+        start: 'none',
+        bottom: 'xsmall',
+      },
+    },
+    info: {
+      size: 'xsmall',
+      color: 'text-xweak',
+      margin: {
+        start: 'none',
+      },
+    },
+    label: {
+      size: 'xsmall',
+      color: 'text-weak',
+      margin: {
+        horizontal: 'none',
+      },
     },
     round: '4px',
   },
@@ -373,6 +412,9 @@ export const hpe = deepFreeze({
     size: {
       xxlarge: '166px',
     },
+  },
+  layer: {
+    background: 'background',
   },
   paragraph: {
     small: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -230,8 +230,8 @@ export const hpe = deepFreeze({
     color: 'text-strong',
     toggle: {
       color: {
-        dark: global.colors['text-strong'].dark,
-        light: global.colors['text-strong'].dark,
+        dark: 'background-front',
+        light: 'background',
       },
       background: 'background-back',
     },

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -104,7 +104,7 @@ export const hpe = deepFreeze({
       focus: 'teal!',
       placeholder: 'text-weak',
       input: {
-        weight: 500,
+        weight: 500, // normal 
       },
     },
     font: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -163,14 +163,6 @@ export const hpe = deepFreeze({
       color: 'text',
     },
   },
-  anchor: {
-    color: 'brand',
-    textDecoration: 'none',
-    fontWeight: 500,
-    hover: {
-      textDecoration: 'underline',
-    },
-  },
   button: {
     size: {
       small: {


### PR DESCRIPTION
This moves any theme updates from the design-system repo as of this week's sprint into the published theme.

The only remaining pieces in the design-system aries.js file are extend functions that utilize normalizeColor function from grommet/utils. @halocline mentioned wanting to think more on if we can implement the extend styling without these functions before thinking about adding grommet as a peer dependency. I have left those aspects of the theme in the design-system theme file for now.