### PR TITLE
Update text color to meet better the accessibility guidelines

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -43,7 +43,7 @@ export const hpe = deepFreeze({
       },
       icon: 'text',
       text: {
-        dark: '#EEEEEE',
+        dark: '#FFFFFF',
         light: '#333333',
       },
       'text-strong': {


### PR DESCRIPTION
This PR has resulted from a conversation with @L0ZZI 
The new design shows that the text color on dark mode is #FFFFFF which meets accessibility guidelines better than #EEEEEE.
Simultaneously, we are working on a study for replacing #01A982 as a background color, because even with #FFFFFF text color it is not passing our advanced accessibility requirements, but at least it passes the basic standards and is more complaint than #EEEEEE which fails without question.

See resources:
https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=01A982
vs
https://webaim.org/resources/contrastchecker/?fcolor=EEEEEE&bcolor=01A982