### PR TITLE
Fixed an issue with global.colors.input

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -115,9 +115,6 @@ export const hpe = deepFreeze({
       'graph-2': 'purple',
       focus: 'teal!',
       placeholder: 'text-weak',
-      input: {
-        weight: 500, // normal
-      },
     },
     input: {
       weight: 500,


### PR DESCRIPTION
`global.colors` should be containing only color values or objects with light/dark and color values.