### PR TITLE
Update background-front dark to 354050

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -34,7 +34,7 @@ export const hpe = deepFreeze({
         light: '#EFEFEF',
       },
       'background-front': {
-        dark: '#222938',
+        dark: '#354050',
         light: '#FFFFFF',
       },
       'background-contrast': {


### PR DESCRIPTION
updated color adds greater contrast and addresses issue #30 and follows color style specified in the Figma color palette
https://www.figma.com/file/eZYR3dtWdb9U90QvJ7p3T9/hpe-color?node-id=9%3A28