### PR TITLE
Align Button styles to Figma file

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -62,14 +62,22 @@ export const hpe = deepFreeze({
         light: '#CCCCCC',
         dark: '#444444',
       },
+      'disabled-border': {
+        dark: '#777777',
+        light: '#999999',
+      },
       control: 'brand',
       'active-background': {
-        dark: '#FFFFFF1F',
-        light: '#CCCCCC99',
+        dark: 'background-front',
+        light: 'background-back',
       },
       'active-text': 'text-strong',
       'selected-background': 'brand',
       'selected-text': 'text-strong',
+      'disabled-text': {
+        dark: '#777777',
+        light: '#999999',
+      },
       'status-critical': '#FF4040',
       'status-warning': '#FFAA15',
       'status-ok': '#00C781',
@@ -225,6 +233,25 @@ export const hpe = deepFreeze({
     extend: css`
       ${props => !props.plain && 'font-weight: bold;'}
     `,
+    disabled: {
+      border: {
+        color: 'disabled-border',
+      },
+      color: 'disabled-text',
+      opacity: 1.0,
+      extend: ({ primary, theme }) =>
+        primary &&
+        `background: transparent; color: ${
+          theme.global.colors['disabled-text'][theme.dark ? 'dark' : 'light']
+        };`,
+    },
+    primary: {
+      active: {
+        border: {
+          color: { dark: 'background-front', light: 'background-back' },
+        },
+      },
+    },
   },
   calendar: {
     small: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -69,14 +69,10 @@ export const hpe = deepFreeze({
       },
       'active-text': 'text',
       'disabled-text': {
-        dark: '#999999',
-        light: '#777777',
-      },
-      'selected-background': 'brand',
-      'disabled-text': {
         dark: '#777777',
         light: '#999999',
       },
+      'selected-background': 'brand',
       'selected-text': '#FFFFFF',
       'status-critical': '#FF4040',
       'status-warning': '#FFAA15',


### PR DESCRIPTION
This aligns the disabled and active styling with what is shown here: https://www.figma.com/file/Oi5UEEQ33VCAyOKQcZ8Nr8/HPE-Button-Component

I did have one comment on the designs for @L0ZZI as to how active buttons would be visible if the background of the page matches the active-background color since that value is no longer using any opacity to create contrast. Left that as a comment on the Figma designs.