### PR TITLE
align checkbox theme with designs

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -272,8 +272,7 @@ export const hpe = deepFreeze({
         `,
     },
     icon: {
-      size: '18px',
-      extend: 'stroke: white;',
+      extend: 'stroke-width: 2px;',
     },
     gap: 'small',
     toggle: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -248,13 +248,37 @@ export const hpe = deepFreeze({
     },
   },
   checkBox: {
-    color: 'selected-text',
-    gap: 'small',
+    border: {
+      color: 'border',
+      width: '1px',
+    },
     check: {
       radius: '2px',
+      extend: ({ theme, checked, indeterminate }) => `
+      ${(checked || indeterminate) && 'border: none;'}
+        ${(checked || indeterminate) &&
+          `background-color: ${theme.global.colors['green!']};`}
+        `,
     },
-    border: {
-      width: '1px',
+    icon: {
+      size: '18px',
+      extend: 'stroke: white;',
+    },
+    gap: 'small',
+    toggle: {
+      background: 'background',
+      color: 'background',
+      knob: {
+        extend: ({ theme }) => `
+           box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.12);
+           border: 1px solid ${
+             theme.global.colors.border[theme.dark ? 'dark' : 'light']
+           }
+        `,
+      },
+      extend: ({ checked, theme }) => `
+      ${checked && `background-color: ${theme.global.colors['green!']};`}
+    `,
     },
   },
   formField: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -256,6 +256,7 @@ export const hpe = deepFreeze({
         color: 'background-contrast',
       },
     },
+    color: 'background',
     border: {
       color: 'border',
       width: '1px',
@@ -265,14 +266,15 @@ export const hpe = deepFreeze({
       extend: ({ theme, checked, indeterminate }) => `
       background-color: ${
         checked || indeterminate
-          ? theme.global.colors['green!']
+          ? theme.global.colors.green[theme.dark ? 'dark' : 'light']
           : theme.global.colors.background[theme.dark ? 'dark' : 'light']
       };
       ${(checked || indeterminate) && 'border: none;'}
         `,
     },
     icon: {
-      extend: 'stroke-width: 2px;',
+      extend: `stroke-width: 2px;
+      stroke: white;`,
     },
     gap: 'small',
     toggle: {
@@ -281,15 +283,18 @@ export const hpe = deepFreeze({
       knob: {
         extend: ({ theme }) => `
            box-shadow: ${
-              theme.global.elevation[theme.dark ? 'dark' : 'light'].small
-            };
+             theme.global.elevation[theme.dark ? 'dark' : 'light'].small
+           };
            border: 1px solid ${
              theme.global.colors.border[theme.dark ? 'dark' : 'light']
            }
         `,
       },
       extend: ({ checked, theme }) => `
-        ${checked && `background-color: ${theme.global.colors['green!']};`}
+        ${checked &&
+          `background-color: ${
+            theme.global.colors.green[theme.dark ? 'dark' : 'light']
+          };`}
       `,
     },
     extend: ({ theme }) => `

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -248,6 +248,14 @@ export const hpe = deepFreeze({
     },
   },
   checkBox: {
+    hover: {
+      border: {
+        color: undefined,
+      },
+      background: {
+        color: 'background-contrast',
+      },
+    },
     border: {
       color: 'border',
       width: '1px',
@@ -255,9 +263,12 @@ export const hpe = deepFreeze({
     check: {
       radius: '2px',
       extend: ({ theme, checked, indeterminate }) => `
+      background-color: ${
+        checked || indeterminate
+          ? theme.global.colors['green!']
+          : theme.global.colors.background[theme.dark ? 'dark' : 'light']
+      };
       ${(checked || indeterminate) && 'border: none;'}
-        ${(checked || indeterminate) &&
-          `background-color: ${theme.global.colors['green!']};`}
         `,
     },
     icon: {
@@ -280,8 +291,15 @@ export const hpe = deepFreeze({
       ${checked && `background-color: ${theme.global.colors['green!']};`}
     `,
     },
+    extend: `
+    width: 100%;
+    padding: 12px;
+`,
   },
   formField: {
+    content: {
+      pad: undefined,
+    },
     border: {
       error: {
         color: 'border',


### PR DESCRIPTION
## Work Completed 

- Aligned checkbox colors to match designs
- would depend on grommet [change](https://github.com/grommet/grommet/pull/3965) 

https://www.figma.com/file/7Mm1xDBTOtPHqggEVpaD2N/HPE-Checkbox-Component?node-id=1390%3A458

following would be added once grommet is merged in 

```
  checkbox: {
    box: {
      extend: ({ theme }) => `
        background-color: ${
          theme.global.colors.background[theme.dark ? 'dark' : 'light']
        };
        border-radius: 4px;
      `,
    },
}

```