### PR TITLE
Update colors based on latest swatches

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -548,8 +548,8 @@ export const hpe = deepFreeze({
     pad: 'small',
     margin: 'none',
     extend: ({ theme }) => css`
-      border-top-left-radius: ${theme.global.control.border.radius};
-      border-top-right-radius: ${theme.global.control.border.radius};
+      border-top-left-radius: ${theme.global.control.border.radius}; // should use radius property of border
+      border-top-right-radius: ${theme.global.control.border.radius}; // should use radius property of border
       font-weight: bold;
     `,
   },

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -537,12 +537,12 @@ export const hpe = deepFreeze({
     },
     border: {
       side: 'bottom',
-      color: 'background-back',
+      color: 'border',
       active: {
-        color: 'border',
+        color: 'border-strong',
       },
       hover: {
-        color: 'background-back',
+        color: 'border',
       },
     },
     pad: 'small',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -26,24 +26,24 @@ export const hpe = deepFreeze({
       'neutral-4': undefined,
       brand: 'green!',
       background: {
-        dark: '#1A1F2B',
+        dark: '#263040',
         light: '#FFFFFF',
       },
       'background-back': {
-        dark: '#1A1F2B',
+        dark: '#263040',
         light: '#EFEFEF',
       },
       'background-front': {
-        dark: '#354050',
+        dark: '#404B5C',
         light: '#FFFFFF',
       },
       'background-contrast': {
-        dark: '#FFFFFF1F',
-        light: '#CCCCCC99',
+        dark: '#FFFFFF14',
+        light: '#0000000A',
       },
       icon: 'text',
       text: {
-        dark: '#FFFFFF',
+        dark: '#C0CADC',
         light: '#444444',
       },
       'text-strong': {
@@ -51,12 +51,20 @@ export const hpe = deepFreeze({
         light: '#000000',
       },
       'text-weak': {
-        dark: '#AAAAAA',
-        light: '#666666',
+        dark: '#606B7D',
+        light: '#BBBBBB',
       },
       border: {
-        dark: '#DDDDDD',
+        dark: '#7887A1',
+        light: '#999999',
+      },
+      'border-strong': {
+        dark: '#AFBCD2',
         light: '#666666',
+      },
+      'border-weak': {
+        dark: '#606B7D',
+        light: '#BBBBBB',
       },
       control: 'brand',
       'active-background': {
@@ -69,45 +77,51 @@ export const hpe = deepFreeze({
         light: '#777777',
       },
       'selected-background': 'brand',
-      'selected-text': '#FFFFFF',
-      'status-critical': '#FF4040',
-      'status-warning': '#FFAA15',
-      'status-ok': '#00C781',
-      'status-unknown': '#CCCCCC',
+      'selected-text': 'text-strong',
+      'status-critical': {
+        dark: 'red!',
+        light: 'red',
+      },
+      'status-warning': 'orange',
+      'status-ok': 'green',
+      'status-unknown': {
+        dark: '#4F5F76',
+        light: '#CCCCCC',
+      },
       'status-disabled': '#CCCCCC',
       blue: {
-        dark: '#0E5265',
+        dark: '#00567A',
         light: '#00C8FF',
       },
       'blue!': '#00739D',
       green: {
-        dark: '#007A5E',
-        light: '#6FFFB0',
+        dark: '#008567',
+        light: '#17EBA0',
       },
       'green!': '#01A982',
       teal: {
-        dark: '#007366',
+        dark: '#117B82',
         light: '#82FFF2',
       },
       'teal!': '#00E8CF',
       purple: {
-        dark: '#371177',
+        dark: '#6633BC',
         light: '#F740FF',
       },
       'purple!': '#7630EA',
       red: {
-        dark: '#4B1916',
-        light: '#FF4F4F',
+        dark: '#A2423D',
+        light: '#FC6161',
       },
-      'red!': '#FF0000',
+      'red!': '#C54E4B',
       orange: {
-        dark: '#CC4B00',
-        light: '#FFB024',
+        dark: '#9B6310',
+        light: '#FFBC44',
       },
       'orange!': '#FF8300',
       yellow: {
-        dark: '#D78F00',
-        light: '#FFEB59',
+        dark: '#8D741C',
+        light: '#FFD63E',
       },
       'yellow!': '#FEC901',
       'graph-0': 'orange!',
@@ -270,7 +284,7 @@ export const hpe = deepFreeze({
     },
     error: {
       background: {
-        color: { light: '#FF404033', dark: '#FF40404D' },
+        color: { light: '#FC6161', dark: '#C54E4B' },
       },
       size: 'xsmall',
       color: 'text-weak',
@@ -503,16 +517,31 @@ export const hpe = deepFreeze({
     },
   },
   tab: {
+    color: 'text',
+    active: {
+      background: 'background-contrast',
+    },
+    hover: {
+      background: 'background-contrast',
+      color: 'text',
+    },
     border: {
-      color: 'text-xweak',
+      side: 'bottom',
+      color: 'background-back',
+      active: {
+        color: 'border',
+      },
+      hover: {
+        color: 'background-back',
+      },
     },
-    color: 'text-xweak',
-    margin: {
-      horizontal: 'none',
-    },
-    pad: {
-      horizontal: 'small',
-    },
+    pad: 'small',
+    margin: 'none',
+    extend: ({ theme }) => css`
+      border-top-left-radius: ${theme.global.control.border.radius};
+      border-top-right-radius: ${theme.global.control.border.radius};
+      font-weight: bold;
+    `,
   },
   text: {
     xsmall: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -300,7 +300,7 @@ export const hpe = deepFreeze({
     },
     error: {
       background: {
-        color: { light: '#FC6161', dark: '#C54E4B' },
+        color: { light: '#FC61613D', dark: '#C54E4B5C' },
       },
       size: 'xsmall',
       color: 'text-weak',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -122,7 +122,7 @@ export const hpe = deepFreeze({
       'orange!': '#FF8300',
       yellow: {
         dark: '#8D741C',
-        light: '#FFD63E',
+        light: '#FFEB59',
       },
       'yellow!': '#FEC901',
       'graph-0': 'orange!',


### PR DESCRIPTION
### In this PR
This updates color values/names as well as tab styling (since some is reliant on these values). I am updating everything that has a 1:1 mapping or could easily added but outstanding issues are noted at the bottom of this PR.

The values are coming from here: https://www.figma.com/file/eZYR3dtWdb9U90QvJ7p3T9/HPE-Color-Styles?node-id=590%3A981

### Items that need to be addressed separately:
- [ ] How will these new validation colors play out in a form? I believe it will require some grommet changes, but I'm curious if the styles will be opt-in depending on the form or if they'll automatically be applied: 
<img width="453" alt="Screen Shot 2020-04-21 at 3 56 20 PM" src="https://user-images.githubusercontent.com/12522275/79923706-f8eba480-83ea-11ea-83d9-fe9085a1e217.png">

- [ ] formField.disabled.background has not been updated. Currently, global.opacity.medium is being applied to disabled formFields, so applying a color of `#0000000f` gets over-ridden by rgba(0,0,0,0.4) in the DOM. I haven't filled in this value because it will make disabled fields too dark. Need to look into fix more.
- [ ] Control colors of primary/secondary need to be discussed a little more -- are these just for Button or will this apply to other control components like menu, etc. where a control color is sometimes used?