### PR TITLE
update pad and icon color

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -303,8 +303,7 @@ export const hpe = deepFreeze({
         `,
     },
     icon: {
-      extend: `stroke-width: 2px;
-      stroke: white;`,
+      extend: `stroke-width: 2px;`,
     },
     gap: 'small',
     toggle: {
@@ -336,7 +335,7 @@ export const hpe = deepFreeze({
         };
       }
       width: 100%;
-      padding: ${theme.global.edgeSize.small};
+      padding: ${theme.global.edgeSize.xsmall} ${theme.global.edgeSize.small};
     `,
   },
   formField: {


### PR DESCRIPTION
Padding was incorrect for vertical so now should be 6px bottom and top and 12px left and right

color of icon got changed to black for light designs and white for dark so no need to force both to be white
