### PR TITLE
update colors take out border focus color

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -297,6 +297,8 @@ export const hpe = deepFreeze({
     check: {
       radius: '2px',
       extend: ({ theme, checked, indeterminate }) => `
+      box-shadow: none;
+      border-color: unset;
       background-color: ${
         checked || indeterminate
           ? theme.global.colors.green[theme.dark ? 'dark' : 'light']
@@ -306,7 +308,10 @@ export const hpe = deepFreeze({
         `,
     },
     icon: {
-      extend: `stroke-width: 2px;`,
+      extend: ({ theme }) => `stroke-width: 2px;
+      stroke: ${
+        theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
+      }`,
     },
     gap: 'small',
     toggle: {


### PR DESCRIPTION
since focus is updated with `formfield` I checked behavior and the outline is now on `formfield` and you can still press space bar to uncheck and check checkbox. I just took out border color that `checkbox` came with originally

designs are now having `text-strong` for icon color 