### PR TITLE
fix option vertical pad

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -535,7 +535,9 @@ export const hpe = deepFreeze({
       up: FormUp,
     },
     options: {
-      pad: { horizontal: 'small', vertical: 'xsmall' },
+      container: {
+        pad: { horizontal: 'small', vertical: 'xsmall' },
+      },
       text: {
         size: 'small',
       },


### PR DESCRIPTION
Correcting where Select option pad is placed. Should be `select.options.container.pad`.