### PR TITLE
Use text-strong for Menu icon

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -543,6 +543,11 @@ export const hpe = deepFreeze({
   layer: {
     background: 'background',
   },
+  menu: {
+    icons: {
+      color: 'text-strong',
+    },
+  },
   paragraph: {
     small: {
       size: '16px',


### PR DESCRIPTION
Uses 'text-strong' for Menu icon.

Dependent on this Grommet PR: https://github.com/grommet/grommet/pull/4031