### PR TITLE
Add overlay background to layer

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -542,6 +542,9 @@ export const hpe = deepFreeze({
   },
   layer: {
     background: 'background',
+    overlay: {
+      background: '#00000080',
+    },
   },
   menu: {
     icons: {


### PR DESCRIPTION
Apply '#00000080' as the overlay background in both light and dark mode

Design: https://www.figma.com/file/eZYR3dtWdb9U90QvJ7p3T9/HPE-Color-Styles?node-id=717%3A9