### PR TITLE
Placeholder text to use 'text-weak'

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -128,7 +128,7 @@ export const hpe = deepFreeze({
       'graph-3': 'yellow!',
       'graph-4': 'teal!',
       focus: 'teal!',
-      placeholder: 'disabled-text',
+      placeholder: 'text-weak',
     },
     input: {
       font: {


### PR DESCRIPTION
Reviewing designs and found the placeholder text should now be using 'text-weak'