### PR TITLE
border for focus and error should be 'border-strong' per designs

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -358,7 +358,7 @@ export const hpe = deepFreeze({
     },
     border: {
       error: {
-        color: 'border',
+        color: 'border-strong',
       },
       color: 'border',
       side: 'all',
@@ -382,6 +382,11 @@ export const hpe = deepFreeze({
       color: 'text',
       margin: {
         start: 'none',
+      },
+    },
+    focus: {
+      border: {
+        color: 'border-strong',
       },
     },
     help: {


### PR DESCRIPTION
This will fix the issue with the border color that was found when in focus and error state.

Inserting comment from slack 

> The only things I am seeing are 1) Figma shows formFields having a ‘border-strong’ upon focus, and 2) Figma shows formFields having ‘border-strong’ on error state — currently Designer and Site leave border color as ‘border’ in both of those states.