### PR TITLE
remove extra padding from select

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -696,6 +696,9 @@ export const hpe = deepFreeze({
     },
   },
   select: {
+    control: {
+      extend: 'padding: 0px;',
+    },
     icons: {
       color: 'text',
       down: FormDown,


### PR DESCRIPTION
Closes https://github.com/hpe-design/design-system/issues/768

Description:
When `<Select>` was being used without being contained in a `<FormField>` it was receiving extra padding from the `<StyledSelectDropButton>`. Removing the undesired padding.