### PR TITLE
update margins based on Slack thread 5-12-2020

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -466,10 +466,19 @@ export const hpe = deepFreeze({
       },
       size: 'xsmall',
       color: 'text',
-      margin: {
-        start: 'none',
-      },
+      margin: 'none',
     },
+    extend: `
+      // This selector will work when label or help
+      // are passed strings. However, it will be too
+      // broad in situations where a node is passed.
+      // The proper solution should be supporting a
+      // formField.input.margin or formField.input in 
+      // the theme.
+      > div:first-of-type {
+        margin: 4px 0px;
+      }
+    `,
     focus: {
       border: {
         color: 'border-strong',
@@ -478,17 +487,12 @@ export const hpe = deepFreeze({
     help: {
       size: 'xsmall',
       color: 'text',
-      margin: {
-        start: 'none',
-        bottom: '4px',
-      },
+      margin: 'none',
     },
     info: {
       size: 'xsmall',
       color: 'text',
-      margin: {
-        start: 'none',
-      },
+      margin: 'none',
     },
     label: {
       size: 'xsmall',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -486,6 +486,7 @@ export const hpe = deepFreeze({
   },
   formField: {
     content: {
+      margin: { vertical: 'xsmall' },
       pad: { vertical: 'xsmall' },
     },
     border: {
@@ -514,17 +515,6 @@ export const hpe = deepFreeze({
       color: 'text',
       margin: 'none',
     },
-    extend: `
-      // This selector will work when label or help
-      // are passed strings. However, it will be too
-      // broad in situations where a node is passed.
-      // The proper solution should be supporting a
-      // formField.input.margin or formField.input in 
-      // the theme.
-      > div:first-of-type {
-        margin: 4px 0px;
-      }
-    `,
     focus: {
       border: {
         color: 'border-strong',
@@ -543,9 +533,7 @@ export const hpe = deepFreeze({
     label: {
       size: 'xsmall',
       color: 'text',
-      margin: {
-        horizontal: 'none',
-      },
+      margin: 'none',
       weight: 500,
     },
     round: '4px',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -480,7 +480,7 @@ export const hpe = deepFreeze({
       color: 'text',
       margin: {
         start: 'none',
-        bottom: 'xsmall',
+        bottom: '4px',
       },
     },
     info: {
@@ -493,9 +493,7 @@ export const hpe = deepFreeze({
     label: {
       size: 'xsmall',
       color: 'text',
-      margin: {
-        horizontal: 'none',
-      },
+      margin: 'none',
       weight: 600,
     },
     round: '4px',


### PR DESCRIPTION
[Figma](https://www.figma.com/file/fZJdRcNrvZ1JjdPRYHpFFU/HPE-Select-Component?node-id=103%3A140)

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates FormField label and help text margins to complete alignment with Figma - [Issue](https://github.com/hpe-design/design-system/issues/818).

Figma design calls for no spacing between label and help text. Previously, bottom margin was set in the theme at the label, help, error, info levels. This created unwanted spacing when label and help were together. This removes the margin from those elements and transfers the desired vertical margin to the FormFieldContentBox instead.

#### Should this PR be placed on the NEXT branch (design-system theme)?

Yes.

#### What testing has been done on this PR?

Applied to aries.js on the Design System site. Screenshots below.

#### Any background context you want to provide?

This approach was dependent on a change in Grommet FormField to allow for margin to be specified via theme [PR](https://github.com/grommet/grommet/pull/4148).

#### What are the relevant issues?
https://github.com/hpe-design/design-system/issues/818
[Slack thread](https://hpe.slack.com/archives/GPPLUK6LR/p1589304674002700)

#### Screenshots (if appropriate)

**Before** -- Note the unwanted spacing between the label and the help text.
![Screen Shot 2020-08-11 at 9 00 42 AM](https://user-images.githubusercontent.com/1756948/89916622-1076b500-dbb5-11ea-8b2f-276e46f8ac1e.png)

**After** -- Unwanted spacing eliminated. Spacing between formField content box and label/help/error/info text maintained.
![Screen Shot 2020-08-11 at 9 16 56 AM](https://user-images.githubusercontent.com/1756948/89916630-140a3c00-dbb5-11ea-92d7-c06a729425ae.png)


#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

This would be a breaking change when we merge NEXT into Master, it modifies the spacing between FormField label texts.

#### How should this PR be communicated in the release notes?
Implemented FormField label and input spacing to align with Figma designs.