### PR TITLE
add auto for width

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -434,7 +434,7 @@ export const hpe = deepFreeze({
           ]
         };
       }
-      width: 100%;
+      width: auto;
       padding: ${theme.global.edgeSize.xsmall} ${theme.global.edgeSize.small};
     `,
   },


### PR DESCRIPTION
![Screen Shot 2020-05-21 at 12 54 59 PM](https://user-images.githubusercontent.com/42451602/82595874-98739280-9b63-11ea-960b-95410c3b34c1.png)

Width was set at 100% which was expanding outside the `formfield` parent 

now that width is auto it will not expand past the parent container

![Screen Shot 2020-05-21 at 12 54 36 PM](https://user-images.githubusercontent.com/42451602/82595954-bb05ab80-9b63-11ea-8f71-31e038fa3f93.png)
