### PR TITLE
Applying font weight for primary and secondary

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -244,12 +244,12 @@ export const hpe = deepFreeze({
     default: {
       color: 'text',
       border: undefined,
+      font: {
+        weight: 700,
+      },
       padding: {
         horizontal: '12px',
         vertical: '6px',
-      },
-      font: {
-        weight: 700,
       },
     },
     primary: {
@@ -258,6 +258,9 @@ export const hpe = deepFreeze({
       },
       border: undefined,
       color: 'text-strong',
+      font: {
+        weight: 700,
+      },
       padding: {
         horizontal: '12px',
         vertical: '6px',
@@ -269,6 +272,9 @@ export const hpe = deepFreeze({
         width: '2px',
       },
       color: 'text',
+      font: {
+        weight: 700,
+      },
       padding: {
         horizontal: '10px',
         vertical: '4px',


### PR DESCRIPTION
Fixes https://github.com/grommet/grommet-theme-hpe/issues/80

Also need to add `font` and `opacity` to Button documentation and `base.js` on Grommet.