### PR TITLE
No border between list items

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -690,6 +690,11 @@ export const hpe = deepFreeze({
       background: '#00000080',
     },
   },
+  list: {
+    item: {
+      border: undefined,
+    },
+  },
   menu: {
     icons: {
       color: 'text-strong',


### PR DESCRIPTION
[Figma designs](https://www.figma.com/file/tMYTr17r6hhGajSlNRiPje/HPE-List-Component?node-id=0%3A1) call for no border between list items by default. This removes the border. Tested locally in design system site.