### PR TITLE
Update status critical color

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -78,8 +78,8 @@ export const hpe = deepFreeze({
       'selected-background': 'green',
       'selected-text': 'text-strong',
       'status-critical': {
-        dark: 'red!',
-        light: 'red',
+        dark: '#FC5A5A',
+        light: '#D04F4E',
       },
       'status-warning': 'orange',
       'status-ok': 'green',


### PR DESCRIPTION
Updates `status-critical` to match new colors proposed by Greg. Discussion for this change can be found here: https://github.com/hpe-design/design-system/issues/945

Closes https://github.com/hpe-design/design-system/issues/989