### PR TITLE
add error validation to color

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -118,7 +118,7 @@ export const hpe = deepFreeze({
         light: '#FFBC44',
       },
       'orange!': '#FF8300',
-      'validation-error': {
+      'validation-critical': {
         light: '#FC61613D',
         dark: '#C54E4B5C',
       },
@@ -510,7 +510,7 @@ export const hpe = deepFreeze({
     },
     error: {
       background: {
-        color: 'validation-error',
+        color: 'validation-critical',
       },
       size: 'xsmall',
       color: 'text',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,12 +2,12 @@
 import { css } from 'styled-components';
 import { FormDown, FormUp } from 'grommet-icons';
 
-const isObject = (item) =>
+const isObject = item =>
   item && typeof item === 'object' && !Array.isArray(item);
 
-const deepFreeze = (obj) => {
+const deepFreeze = obj => {
   Object.keys(obj).forEach(
-    (key) => key && isObject(obj[key]) && Object.freeze(obj[key]),
+    key => key && isObject(obj[key]) && Object.freeze(obj[key]),
   );
   return Object.freeze(obj);
 };

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -118,6 +118,10 @@ export const hpe = deepFreeze({
         light: '#FFBC44',
       },
       'orange!': '#FF8300',
+      'validation-error': {
+        light: '#FC61613D',
+        dark: '#C54E4B5C',
+      },
       yellow: {
         dark: '#8D741C',
         light: '#FFEB59',
@@ -462,10 +466,12 @@ export const hpe = deepFreeze({
         `,
       },
       extend: ({ checked, theme }) => `
-        ${checked &&
+        ${
+          checked &&
           `background-color: ${
             theme.global.colors.green[theme.dark ? 'dark' : 'light']
-          };`}
+          };`
+        }
       `,
     },
     extend: ({ theme }) => `
@@ -504,7 +510,7 @@ export const hpe = deepFreeze({
     },
     error: {
       background: {
-        color: { light: '#FC61613D', dark: '#C54E4B5C' },
+        color: 'validation-error',
       },
       size: 'xsmall',
       color: 'text',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,12 +2,12 @@
 import { css } from 'styled-components';
 import { FormDown, FormUp } from 'grommet-icons';
 
-const isObject = item =>
+const isObject = (item) =>
   item && typeof item === 'object' && !Array.isArray(item);
 
-const deepFreeze = obj => {
+const deepFreeze = (obj) => {
   Object.keys(obj).forEach(
-    key => key && isObject(obj[key]) && Object.freeze(obj[key]),
+    (key) => key && isObject(obj[key]) && Object.freeze(obj[key]),
   );
   return Object.freeze(obj);
 };
@@ -466,12 +466,10 @@ export const hpe = deepFreeze({
         `,
       },
       extend: ({ checked, theme }) => `
-        ${
-          checked &&
+        ${checked &&
           `background-color: ${
             theme.global.colors.green[theme.dark ? 'dark' : 'light']
-          };`
-        }
+          };`}
       `,
     },
     extend: ({ theme }) => `


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds the color we are using for `formfield` to colors
#### Should this PR be placed on the NEXT branch (design-system theme)?

#### What testing has been done on this PR?
aries-site
#### Any background context you want to provide?
Needed a new color namespace in order to call easily 
#### What are the relevant issues?
https://github.com/hpe-design/design-system/issues/1009
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
