### PR TITLE
Revert "add error validation to color"

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -118,10 +118,6 @@ export const hpe = deepFreeze({
         light: '#FFBC44',
       },
       'orange!': '#FF8300',
-      'validation-critical': {
-        light: '#FC61613D',
-        dark: '#C54E4B5C',
-      },
       yellow: {
         dark: '#8D741C',
         light: '#FFEB59',
@@ -508,7 +504,7 @@ export const hpe = deepFreeze({
     },
     error: {
       background: {
-        color: 'validation-critical',
+        color: { light: '#FC61613D', dark: '#C54E4B5C' },
       },
       size: 'xsmall',
       color: 'text',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

The latest changes re: validation-critical failed on CI because the grommet-icons tarball was out of date. This PR was going to revert those changes to open a new PR , but the same thing is happening.

#### Should this PR be placed on the NEXT branch (design-system theme)?

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
