### PR TITLE
Removes spacing between radiobutton options when in RadioButtonGroup

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -761,6 +761,9 @@ export const hpe = deepFreeze({
       },
     },
   },
+  radioButtonGroup: {
+    container: { gap: 'none' },
+  },
   rangeInput: {
     track: {
       color: 'background-contrast',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Aligns theme with [Figma Designs]() by removing spacing between radiobutton options when in RadioButtonGroup.

#### Should this PR be placed on the NEXT branch (design-system theme)?

Yes

#### What testing has been done on this PR?

Applied in aries.js on Design System site. Screenshots below.

#### Any background context you want to provide?

This work was enabled by a newly available theme feature. [PR](https://github.com/grommet/grommet/pull/4383)

#### What are the relevant issues?

https://github.com/hpe-design/design-system/issues/897
https://github.com/grommet/grommet/pull/4383

#### Screenshots (if appropriate)

**Before**
![Screen Shot 2020-08-11 at 9 16 56 AM](https://user-images.githubusercontent.com/1756948/89919969-1ff7fd00-dbb9-11ea-8161-08edf3c4ac2c.png)

**After**
![Screen Shot 2020-08-11 at 9 17 08 AM](https://user-images.githubusercontent.com/1756948/89920055-37cf8100-dbb9-11ea-9275-42d2b477f1fe.png)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

This would be breaking for any projects using RadioButtonGroup. It will remove any gap between radio button options, unless the `<RadioButtonGroup gap="[is specified]" />` is already specified.

#### How should this PR be communicated in the release notes?
Aligns theme with Figma by removing "gap" from between radio button options.