### PR TITLE
Remove status-error since we use status-critical

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -26,6 +26,7 @@ export const hpe = deepFreeze({
       'neutral-3': undefined,
       'neutral-4': undefined,
       'neutral-5': undefined,
+      'status-error': undefined,
       brand: 'green!',
       background: {
         dark: '#263040',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Sets `status-error` to undefined since the design-system only uses `status-critical`. The two are very similar, so to avoid improper usage, we are removing `error` from the hpe theme.

#### Should this PR be placed on the NEXT branch (design-system theme)?
Yes.

#### What testing has been done on this PR?
Tested local on design-system-site

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/hpe-design/design-system/issues/980

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Breaking change.

#### How should this PR be communicated in the release notes?
Any usage of `status-error` should be changed to `status-critical`.