### PR TITLE
add margin to drop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--- Provide a general summary of the PR in the Title above -->
+
+#### What does this PR do?
+
+#### Should this PR be placed on the NEXT branch (design-system theme)?
+
+#### What testing has been done on this PR?
+
+#### Any background context you want to provide?
+
+#### What are the relevant issues?
+
+#### Screenshots (if appropriate)
+
+#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
+
+#### How should this PR be communictaed in the release notes?

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -186,6 +186,9 @@ export const hpe = deepFreeze({
       border: {
         radius: '4px',
       },
+      extend: ({ theme }) =>
+        `margin-top: ${theme.global.edgeSize.xsmall}; 
+       margin-bottom: ${theme.global.edgeSize.xsmall};`,
       shadowSize: 'medium',
     },
     elevation: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -186,9 +186,11 @@ export const hpe = deepFreeze({
       border: {
         radius: '4px',
       },
-      extend: ({ theme }) =>
-        `margin-top: ${theme.global.edgeSize.xsmall}; 
-       margin-bottom: ${theme.global.edgeSize.xsmall};`,
+      extend: ({ alignProp, theme }) =>
+        `margin-top: ${alignProp.top !== 'top' &&
+          theme.global.edgeSize.xsmall}; 
+        margin-bottom: ${alignProp.bottom !== 'bottom' &&
+          theme.global.edgeSize.xsmall}`,
       shadowSize: 'medium',
     },
     elevation: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds margin for top and bottom of drop 
#### Should this PR be placed on the NEXT branch (design-system theme)?
yes
#### What testing has been done on this PR?
design system to match figma files
#### Any background context you want to provide?
https://github.com/hpe-design/design-system/issues/657
#### What are the relevant issues?
issue #657 on design system
#### Screenshots (if appropriate)

<img width="551" alt="Screen Shot 2020-08-18 at 12 11 41 PM" src="https://user-images.githubusercontent.com/42451602/90549961-7e3e5600-e14c-11ea-9462-da2449666204.png">
<img width="618" alt="Screen Shot 2020-08-18 at 12 11 55 PM" src="https://user-images.githubusercontent.com/42451602/90549965-80081980-e14c-11ea-9f94-d5a3e3ad9858.png">
<img width="867" alt="Screen Shot 2020-08-18 at 12 12 22 PM" src="https://user-images.githubusercontent.com/42451602/90549972-826a7380-e14c-11ea-9bf2-3a4676f2cdb5.png">



<img width="603" alt="Screen Shot 2020-08-18 at 12 11 32 PM" src="https://user-images.githubusercontent.com/42451602/90549936-767eb180-e14c-11ea-93db-0244389301d0.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backward compatible
#### How should this PR be communicated in the release notes?
This should be added that previously there was no margin between `textinput` and `drop` and now it is 6px