### PR TITLE
Update rangeInput to match site

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -773,11 +773,24 @@ export const hpe = deepFreeze({
     container: { gap: 'none' },
   },
   rangeInput: {
-    track: {
-      color: 'background-contrast',
-    },
     thumb: {
-      color: 'text',
+      color: 'background',
+      extend: ({ theme }) => `
+        border: 1px solid ${
+          theme.global.colors.border[theme.dark ? 'dark' : 'light']
+        };
+        box-shadow: ${
+          theme.global.elevation[theme.dark ? 'dark' : 'light'].small
+        };
+      `,
+    },
+    track: {
+      lower: {
+        color: 'green',
+      },
+      upper: {
+        color: 'border',
+      },
     },
   },
   select: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates rangeinput to use new grommet functionality of `track.upper.color` and `track.lower.color` to style rangeInput track.

When cross checking with designs, designs show RangeInput inside of a FormField, but these theme styles apply purely to the rangeInput: https://www.figma.com/file/BqCjvjc0rECQ4Ln2QhyjNi/HPE-Range-Input-Component?node-id=1%3A50

#### Should this PR be placed on the NEXT branch (design-system theme)?
Yes.

#### What testing has been done on this PR?
Tested local in design system site. See screenshots below.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="864" alt="Screen Shot 2020-08-20 at 10 57 05 AM" src="https://user-images.githubusercontent.com/12522275/90808303-a5279400-e2d4-11ea-9a13-aba7aaaadc4a.png">
<img width="822" alt="Screen Shot 2020-08-20 at 10 56 59 AM" src="https://user-images.githubusercontent.com/12522275/90808305-a658c100-e2d4-11ea-921c-af55c3d06b43.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
This is a breaking change.

#### How should this PR be communicated in the release notes?
- **Track color**: 
   - upper: `border` (previously black)
   - lower: `green` (previously black)
- **Thumb:**
   - background color: `background
   - border: 1px solid `border`
   - elevation: small
