### PR TITLE
Fix Select disabled styling

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -796,9 +796,12 @@ export const hpe = deepFreeze({
   select: {
     control: {
       extend: ({ disabled }) => css`
+        ${disabled &&
+          `
+        opacity: 0.3;
         input {
-          ${disabled && 'cursor: default; opacity: 0.3;'}
-        }
+          cursor: default;
+        }`}
       `,
     },
     icons: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -794,6 +794,13 @@ export const hpe = deepFreeze({
     },
   },
   select: {
+    control: {
+      extend: ({ disabled }) => css`
+        input {
+          ${disabled && 'cursor: default; opacity: 0.3;'}
+        }
+      `,
+    },
     icons: {
       color: 'text',
       down: FormDown,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Select, when not inside a FormField, didn't have any disabled styling. While we may want to expand the theming capabilities for this in grommet, for now we are just applying this via theme extend. When Select is disabled, it toggles opacity to 0.3 (matching grommet default for disabled) and keeps cursor as the default as opposed to pointer.

#### Should this PR be placed on the NEXT branch (design-system theme)?
Yes.

#### What testing has been done on this PR?
Test local in design system site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet-theme-hpe/issues/96

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Compatible.

#### How should this PR be communicated in the release notes?
