### PR TITLE
"npm install" fails with branch names, use "yarn"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ From your package.json point to stable.
 ```
 "grommet-theme-hpe": "https://github.com/grommet/grommet-theme-hpe/tarball/stable",
 ```
+
+_NOTE: To install `grommet-theme-hpe` from a branch, use the `yarn` package manager,
+since `npm install` fails to install from a branch name. `npm install` will produce
+the error:_
+
+```
+$ npm install
+npm ERR! code ENOPACKAGEJSON
+...
+```


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Update README.md: When referencing branches, use `yarn` instead of `npm install`.

#### Should this PR be placed on the NEXT branch (design-system theme)?

Yes.

#### What testing has been done on this PR?

Markdown preview.

#### Any background context you want to provide?

None.

#### What are the relevant issues?

Issues #78 and #99.

#### Screenshots (if appropriate)

N/A.

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

Backward compatible.

#### How should this PR be communicated in the release notes?

Updated README.md.
