### PR TITLE
README: yarn required for branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ From your package.json point to NEXT-stable.
 ```
 "grommet-theme-hpe": "https://github.com/grommet/grommet-theme-hpe/tarball/NEXT-stable",
 ```
+
+_NOTE: To install `grommet-theme-hpe` from a branch, use the `yarn` package 
+manager, since `npm install` fails to install from a branch name. `npm install`
+will produce the error:_
+
+```
+$ npm install
+npm ERR! code ENOPACKAGEJSON
+...
+```


### PR DESCRIPTION
npm fails to install from a branch.  Use yarn instead.

See issues #78 and #99.

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Update README to use yarn when installing from a branch.

#### Should this PR be placed on the NEXT branch (design-system theme)?
Yes.

#### What testing has been done on this PR?
Markup preview.

#### Any background context you want to provide?
No.

#### What are the relevant issues?
See issues #78 and #99.

#### Screenshots (if appropriate)
N/A.

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Yes.

#### How should this PR be communicated in the release notes?
Updated README.md.
