### PR TITLE
Temp button disabled fix

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -411,6 +411,13 @@ export const hpe = deepFreeze({
       vertical: '4px',
       horizontal: '10px',
     },
+    // temporary fix so that hoverIndicator does not appear on disabled buttons
+    // issue caused by https://github.com/grommet/grommet/blob/master/src/js/components/Button/StyledButtonKind.js#L256
+    // not checking if button is disabled before applying hoverIndicator
+    // Resolve in next grommet release, then remove this line
+    extend: ({ disabled }) => css`
+      ${disabled && '&:hover { background: transparent; } '}
+    `,
   },
   calendar: {
     small: {
@@ -796,12 +803,7 @@ export const hpe = deepFreeze({
   select: {
     control: {
       extend: ({ disabled }) => css`
-        ${disabled &&
-          `
-        opacity: 0.3;
-        input {
-          cursor: default;
-        }`}
+        ${disabled && 'opacity: 0.3;'}
       `,
     },
     icons: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
hoverIndicator was still being applied to disabled buttons with hoverIndicator because of  https://github.com/grommet/grommet/blob/master/src/js/components/Button/StyledButtonKind.js#L256

This is a temporary fix on the theme until be can resolve this issue from the grommet core in the next grommet release.

#### Should this PR be placed on the NEXT branch (design-system theme)?
Yes.

#### What testing has been done on this PR?
Tested locally in design-system.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
