### PR TITLE
Update tab label color for various states to match design

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -839,10 +839,11 @@ export const hpe = deepFreeze({
     color: 'text-strong',
     active: {
       background: 'background-contrast',
+      color: 'text-strong',
     },
     hover: {
       background: 'background-contrast',
-      color: 'text',
+      color: 'text-strong',
     },
     border: {
       side: 'bottom',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
[Design](https://www.figma.com/file/Kp4dWyhUTnKIJ1Cg5CoL9o/HPE-Tabs-Component?node-id=0%3A1)
On hover and active, Tab label should still be `text-strong`, right now it was `text`. Aligning with designs.


#### What testing has been done on this PR?
Tested locally on design-system site. 

Before:
<img width="457" alt="Screen Shot 2020-10-02 at 12 46 12 PM" src="https://user-images.githubusercontent.com/12522275/94963927-b0620800-04ad-11eb-8620-e5e9aeeccaa6.png">
After:
<img width="454" alt="Screen Shot 2020-10-02 at 12 46 03 PM" src="https://user-images.githubusercontent.com/12522275/94963936-b3f58f00-04ad-11eb-80bb-1f1d5a357c15.png">

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Updates the active/hover colors

#### How should this PR be communicated in the release notes?
When active or hovered over, a Tab label will now have color of `text-strong` as opposed to `text`.