### PR TITLE
Update button label to use text-strong

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -261,7 +261,7 @@ export const hpe = deepFreeze({
   },
   button: {
     default: {
-      color: 'text',
+      color: 'text-strong',
       border: undefined,
       font: {
         weight: 700,
@@ -290,7 +290,7 @@ export const hpe = deepFreeze({
         color: 'green',
         width: '2px',
       },
-      color: 'text',
+      color: 'text-strong',
       font: {
         weight: 700,
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates label color of buttons to use `text-strong` to align with Figma designs.

[Designs](https://www.figma.com/file/Oi5UEEQ33VCAyOKQcZ8Nr8/HPE-Button-Component?node-id=0%3A1)
 
#### What testing has been done on this PR?
Tested locally in design system.

#### Any background context you want to provide?
Updates were made the Figma file that were not reflected in grommet-theme-hpe.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
Button uses `text-strong` as opposed to `text` for label color.