### PR TITLE
Restraining the use of text-xweak

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -30,6 +30,7 @@ export const hpe = deepFreeze({
       'neutral-4': undefined,
       'neutral-5': undefined,
       'status-error': undefined,
+      'text-xweak': undefined,
       brand: 'green!',
       background: {
         dark: '#263040',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -30,7 +30,6 @@ export const hpe = deepFreeze({
       'neutral-4': undefined,
       'neutral-5': undefined,
       'status-error': undefined,
-      'text-xweak': undefined,
       brand: 'green!',
       background: {
         dark: '#263040',
@@ -61,6 +60,7 @@ export const hpe = deepFreeze({
         dark: '#606B7D',
         light: '#BBBBBB',
       },
+      'text-xweak': 'text-weak',
       border: {
         dark: '#7887A1',
         light: '#999999',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
The HPE design-system is providing three options for text colors: `text`, `text-weak`, `text-xweak`.
Though, HPE users still see the `text-xweak` option from the base theme. This PR is restricting the use of this base theme color.

This PR results from a question we've received from GLC:
> I noticed that there is a text-xweak defined in the base grommet theme, but not in the hpe theme - and it is darker than the new text-weak is. Should the hpe theme also be specifying text-xweak so that it is relatively weaker than text-weak?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Might be an issue for HPE users that have used `text-xweak`, the value will be turned to 'undefined'.

#### How should this PR be communicated in the release notes?
Restricting the usage of `text-xweak` as this color isn't supported by the HPE design-system.