### PR TITLE
Adding radioButton check icon per designs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
   },
   "rules": {
     "comma-dangle": ["error", "always-multiline"],
-    "import/prefer-default-export": 0
+    "import/prefer-default-export": 0,
+    "react/jsx-filename-extension": 0
   }
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,8 @@
 // (C) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+import React from 'react';
 import { css } from 'styled-components';
 import { Ascending } from 'grommet-icons/icons/Ascending';
+import { Blank } from 'grommet-icons/icons/Blank';
 import { Descending } from 'grommet-icons/icons/Descending';
 import { FormDown } from 'grommet-icons/icons/FormDown';
 import { FormUp } from 'grommet-icons/icons/FormUp';
@@ -797,6 +799,13 @@ export const hpe = deepFreeze({
       border: {
         color: undefined,
       },
+    },
+    icons: {
+      circle: () => (
+        <Blank color="selected-background">
+          <circle cx="12" cy="12" r="8" />
+        </Blank>
+      ),
     },
   },
   radioButtonGroup: {


### PR DESCRIPTION
- Adding radioButton check icon per designs
- turned off eslint rule for no jsx in .js files
- closes https://github.com/grommet/grommet/issues/4465

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

- Closes https://github.com/grommet/hpe-design-system/issues/851 which calls for a larger check/circle in selected radio buttons.
- Closes https://github.com/grommet/grommet/issues/4465 which asked for ability to specify the check size in the theme. Instead, was asked to try to use the `radioButton.icons.circle` property in the theme which had previously been [undocumented](https://github.com/grommet/grommet/pull/4581).

#### What testing has been done on this PR?

Design System site.

#### Any background context you want to provide?

Above.

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/851
https://github.com/grommet/grommet/issues/4465

#### Screenshots (if appropriate)

![Screen Shot 2020-10-28 at 4 11 49 PM](https://user-images.githubusercontent.com/1756948/97502883-a5c65180-1939-11eb-9090-ff9ecf1b6c03.png)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

Backwards compatible, but should be mentioned in the style changes portion of the [migration guide](https://github.com/grommet/grommet-theme-hpe/wiki/Migration-guide-to-the-design-system-theme#radiobutton).

#### How should this PR be communicated in the release notes?
- RadioButton selected state aligned with Figma. RadioButtonGroup status is now complete. 

(Note: Design System status for the RadioButtonGroup page should also be updated.)
