### PR TITLE
Add icon to formfield error

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { css } from 'styled-components';
 import { Ascending } from 'grommet-icons/icons/Ascending';
 import { Blank } from 'grommet-icons/icons/Blank';
+import { CircleAlert } from 'grommet-icons/icons/CircleAlert';
 import { Descending } from 'grommet-icons/icons/Descending';
 import { FormDown } from 'grommet-icons/icons/FormDown';
 import { FormUp } from 'grommet-icons/icons/FormUp';
@@ -554,6 +555,10 @@ export const hpe = deepFreeze({
       background: {
         color: 'validation-critical',
       },
+      container: {
+        gap: 'xsmall',
+      },
+      icon: <CircleAlert size="small" style={{ marginTop: '4px' }} />,
       size: 'xsmall',
       color: 'text',
       margin: 'none',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `CircleAlert` icon to FormField error to align with [Figma Designs](https://www.figma.com/file/3fkwBelW5UsCbfwdDCJkT8/HPE-Form-Templates?node-id=0%3A1).

#### What testing has been done on this PR?
Already implemented locally in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet-theme-hpe/issues/126

#### Screenshots (if appropriate)
<img width="367" alt="Screen Shot 2020-10-28 at 4 06 34 PM" src="https://user-images.githubusercontent.com/12522275/97506194-980fcc80-1937-11eb-9f67-189deb1f87b5.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible, but will introduce a new icon next to the text that wasn't there previously. Have added to theme migration guide that this is a style change: https://github.com/grommet/grommet-theme-hpe/wiki/Migration-guide-to-the-design-system-theme#formfield

#### How should this PR be communicated in the release notes?
