### PR TITLE
Mark disabled-text as deprecated

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -64,6 +64,7 @@ export const hpe = deepFreeze({
         light: '#BBBBBB',
       },
       'text-xweak': 'text-weak',
+      'text-disabled': 'text-weak',
       border: {
         dark: '#7887A1',
         light: '#999999',
@@ -79,10 +80,7 @@ export const hpe = deepFreeze({
       control: 'green',
       'active-background': 'background-contrast',
       'active-text': 'text',
-      'disabled-text': {
-        dark: '#777777',
-        light: '#999999',
-      },
+      'disabled-text': 'text-disabled', // keeping for backwards compatibility, should deprecate in next release
       'selected-background': 'green',
       'selected-text': 'text-strong',
       'status-critical': {
@@ -342,10 +340,10 @@ export const hpe = deepFreeze({
       background: {
         color: 'transparent',
       },
-      color: 'text-weak',
+      color: 'text-disabled',
       primary: {
         border: {
-          color: 'text-weak',
+          color: 'border-weak',
           width: '2px',
         },
         padding: {
@@ -355,7 +353,7 @@ export const hpe = deepFreeze({
       },
       secondary: {
         border: {
-          color: 'text-weak',
+          color: 'border-weak',
         },
       },
       opacity: 1.0,
@@ -548,7 +546,7 @@ export const hpe = deepFreeze({
         color: 'border-weak',
       },
       label: {
-        color: 'text-weak',
+        color: 'text-disabled',
       },
     },
     error: {
@@ -879,7 +877,7 @@ export const hpe = deepFreeze({
       },
     },
     disabled: {
-      color: 'text-weak',
+      color: 'text-disabled',
     },
     pad: 'small',
     margin: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -64,7 +64,6 @@ export const hpe = deepFreeze({
         light: '#BBBBBB',
       },
       'text-xweak': 'text-weak',
-      'text-disabled': 'text-weak',
       border: {
         dark: '#7887A1',
         light: '#999999',
@@ -80,7 +79,7 @@ export const hpe = deepFreeze({
       control: 'green',
       'active-background': 'background-contrast',
       'active-text': 'text',
-      'disabled-text': 'text-disabled', // keeping for backwards compatibility, should deprecate in next release
+      'disabled-text': 'text-weak', // deprecated, use text-weak instead
       'selected-background': 'green',
       'selected-text': 'text-strong',
       'status-critical': {
@@ -340,7 +339,7 @@ export const hpe = deepFreeze({
       background: {
         color: 'transparent',
       },
-      color: 'text-disabled',
+      color: 'text-weak',
       primary: {
         border: {
           color: 'border-weak',
@@ -546,7 +545,7 @@ export const hpe = deepFreeze({
         color: 'border-weak',
       },
       label: {
-        color: 'text-disabled',
+        color: 'text-weak',
       },
     },
     error: {
@@ -877,7 +876,7 @@ export const hpe = deepFreeze({
       },
     },
     disabled: {
-      color: 'text-disabled',
+      color: 'text-weak',
     },
     pad: 'small',
     margin: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Marks `disabled-text` as deprecated and instructs users to use `text-weak` instead. Updates value of `disabled-text` to `text-weak` just to be consistent. Updates 2 instances of disabled border to use `border-weak` instead of `text-weak` just for semantic alignment.

#### What testing has been done on this PR?
Tested locally in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1102

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible.

#### How should this PR be communicated in the release notes?
`disabled-text` is deprecated. Use `text-weak` instead.