### PR TITLE
Set default input icon color

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -739,6 +739,20 @@ export const hpe = deepFreeze({
       border: undefined,
     },
   },
+  maskedInput: {
+    container: {
+      extend: ({ theme }) => `
+        svg {
+          fill: ${
+            theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
+          };
+          stroke: ${
+            theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
+          };
+        }
+      `,
+    },
+  },
   menu: {
     icons: {
       color: 'text-strong',
@@ -934,6 +948,20 @@ export const hpe = deepFreeze({
       size: '36px',
       height: '42px',
       maxWidth: '854px',
+    },
+  },
+  textInput: {
+    container: {
+      extend: ({ theme }) => `
+        svg {
+          fill: ${
+            theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
+          };
+          stroke: ${
+            theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
+          };
+        }
+      `,
     },
   },
   // Theme-Designer only parameters


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Inputs call for an icon of color `text-strong` by default. This sets that value in the theme so users don't need to set it on each implementation.

Design example can be seen on DateInput: https://www.figma.com/file/Mf9if6zyGETTWW5b9PsYNQ/HPE-Date-Input-Component?node-id=0%3A1

#### What testing has been done on this PR?
Test locally in design system site.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="413" alt="Screen Shot 2020-11-02 at 5 27 20 PM" src="https://user-images.githubusercontent.com/12522275/97936546-b2c7b400-1d30-11eb-8527-f8225f4bc004.png">
<img width="641" alt="Screen Shot 2020-11-02 at 5 27 13 PM" src="https://user-images.githubusercontent.com/12522275/97936548-b3f8e100-1d30-11eb-8e7c-3b197507051c.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
New visual, but not breaking.

#### How should this PR be communicated in the release notes?
By default, icons used in inputs now use `text-strong` instead of `text`.