### PR TITLE
Update placeholder weight and input value weight

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -152,12 +152,25 @@ export const hpe = deepFreeze({
     input: {
       font: {
         height: 'inherit',
-        weight: 400,
+        weight: 500,
       },
       padding: {
         horizontal: 'small',
         vertical: 'xsmall',
       },
+      extend: `
+        &::-webkit-input-placeholder {
+          font-weight: 400;
+        }
+      
+        &::-moz-placeholder {
+          font-weight: 400;
+        }
+      
+        &:-ms-input-placeholder {
+          font-weight: 400;
+        }
+      `,
     },
     font: {
       family: "'Metric', Arial, sans-serif",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adjust input weight to match designs. Input value calls for 500 and placeholder calls for 400. The `global.input.extend` is currently only present on grommet stable (not a released version), so we won't see these changes in effect until the next grommet release.

#### What testing has been done on this PR?
Tested locally on DS site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1005

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
New visual look but not a breaking change.

#### How should this PR be communicated in the release notes?
Input value uses weight of 500 (medium) and placeholder uses weight of 400 (normal).