### PR TITLE
Mark status-disabled as deprecated

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -101,7 +101,7 @@ export const hpe = deepFreeze({
         dark: '#4F5F76',
         light: '#CCCCCC',
       },
-      'status-disabled': '#CCCCCC',
+      'status-disabled': '#CCCCCC', // deprecated, does not support light and dark. use text-weak instead
       blue: {
         dark: '#00567A',
         light: '#00C8FF',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
`status-disabled` is not being used anywhere in the theme except its definition and it is not being used in any of the design system designs. in cases of disabled, either `text-weak` or `border-weak` is used. This adds a comment that marks this as deprecated and provides guidance on which color should we used instead.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1103

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible.

#### How should this PR be communicated in the release notes?
`status-disabled` should not be used. Instead, use `text-weak`.