### PR TITLE
Modify FormField margins to align with Figma

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -571,7 +571,11 @@ export const hpe = deepFreeze({
       icon: <CircleAlert size="small" style={{ marginTop: '4px' }} />,
       size: 'xsmall',
       color: 'text',
-      margin: 'none',
+      margin: {
+        bottom: 'xsmall',
+        top: 'none',
+        horizontal: 'none',
+      },
     },
     focus: {
       border: {
@@ -586,13 +590,24 @@ export const hpe = deepFreeze({
     info: {
       size: 'xsmall',
       color: 'text',
-      margin: 'none',
+      margin: {
+        bottom: 'xsmall',
+        top: 'none',
+        horizontal: 'none',
+      },
     },
     label: {
       size: 'xsmall',
       color: 'text',
-      margin: 'none',
+      margin: {
+        bottom: 'none',
+        top: 'xsmall',
+        horizontal: 'none',
+      },
       weight: 500,
+    },
+    margin: {
+      bottom: 'none',
     },
     round: '4px',
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Modifies FormField margins to align with Figma by adjusting where margins are applied.

[Figma](https://www.figma.com/file/3fkwBelW5UsCbfwdDCJkT8/HPE-Form-Templates?node-id=54%3A14) calls for 12px of spacing between form fields. However, this spacing was too large in certain circumstances (18px instead of the desired 12px).

The old way:
- formField label, help, error, info had zero margin
- `formField.content.margin.vertical` = 6px
- `formField.margin.bottom` = 12px

This resulted in scenarios where if there were no error message, the spacing between that FormField and the following would have 18px of spacing in between (6px from `formField.content.margin.bottom` + 12px from `formField.margin.bottom`)

The new way:
- `formField.label.margin.top` = 6px
- `formField.error.margin.bottom` = 6px
- `formField.content.margin.vertical` = 6px

This approach ensures that regardless of whether a label or error message are present or not, the configuration of the FormField will always have 6px top and bottom margins and the desired 12px of spacing between fields.

#### What testing has been done on this PR?

Design System site, plus [Applitools preview deploy](https://eyes.applitools.com/app/test-results/00000251796652620064/?accountId=diU-zN8vi0mdpzHhZndu1A~~).

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/1256

#### Screenshots (if appropriate)

Diff shows expected shift in new vs. baseline, and results in correct spacing of 12px instead of 18px:
![Screen Shot 2020-11-17 at 2 45 04 PM](https://user-images.githubusercontent.com/1756948/99454546-ce5fbc80-28e3-11eb-9fb8-b4e7bd0b7e2a.png)
![Screen Shot 2020-11-17 at 2 45 14 PM](https://user-images.githubusercontent.com/1756948/99454552-d15aad00-28e3-11eb-9cf3-60089c9a3caa.png)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible, but will result in a visual regression of 6px shifts between form fields.

#### How should this PR be communicated in the release notes?
Modified spacing between FormFields in theme to align with Figma.
