### PR TITLE
Adjust grouped input theming

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -549,6 +549,7 @@ export const hpe = deepFreeze({
   formField: {
     content: {
       margin: { vertical: 'xsmall' },
+      pad: undefined,
     },
     border: {
       error: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -478,7 +478,6 @@ export const hpe = deepFreeze({
       radius: '2px',
       extend: ({ theme, checked, indeterminate }) => `
       box-shadow: none;
-      border-color: unset;
       background-color: ${
         checked || indeterminate
           ? theme.global.colors.green[theme.dark ? 'dark' : 'light']
@@ -523,9 +522,18 @@ export const hpe = deepFreeze({
           ]
         };
       }`}
+      font-weight: 500;
       width: auto;
       padding: ${theme.global.edgeSize.xsmall} ${theme.global.edgeSize.small};
     `,
+  },
+  checkBoxGroup: {
+    container: {
+      gap: 'none',
+      margin: {
+        vertical: 'xsmall',
+      },
+    },
   },
   dataTable: {
     icons: {
@@ -541,7 +549,6 @@ export const hpe = deepFreeze({
   formField: {
     content: {
       margin: { vertical: 'xsmall' },
-      pad: { vertical: 'xsmall' },
     },
     border: {
       error: {
@@ -816,6 +823,7 @@ export const hpe = deepFreeze({
           ]
         };
       }
+      font-weight: 500;
       width: auto;
       padding: ${theme.global.edgeSize.xxsmall} ${theme.global.edgeSize.xsmall};
     `,
@@ -838,7 +846,12 @@ export const hpe = deepFreeze({
     },
   },
   radioButtonGroup: {
-    container: { gap: 'none' },
+    container: {
+      gap: 'none',
+      margin: {
+        vertical: 'xsmall',
+      },
+    },
   },
   rangeInput: {
     thumb: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
CheckBoxGroup and RadioButtonGroup call for `xsmall` space on top and bottom, but individual checkbox should fully fill the formfield. This adjust the styling to the margin comes from the `RadioButtonGroup` and `CheckBoxGroup` themselves as opposed to the FormField.

Two additional clean-ups:
1. checkbox border was being `unset` which did't allow the border color to be applied properly. this has been removed.
2. radiobutton and checkbox call for labels to be weight of 500. this PR applies that.

#### What testing has been done on this PR?
Tested locally in aries-site.

#### Any background context you want to provide?
Checkbox on hover was not filling the formfield fully, this did not align with designs.

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1246

#### Screenshots (if appropriate)
<img width="385" alt="Screen Shot 2020-11-18 at 8 43 52 AM" src="https://user-images.githubusercontent.com/12522275/99590300-03324900-29a2-11eb-8aa7-4c903cb6614c.png">
<img width="382" alt="Screen Shot 2020-11-18 at 8 43 47 AM" src="https://user-images.githubusercontent.com/12522275/99590306-04637600-29a2-11eb-9ae3-4fa7f48f9414.png">
<img width="389" alt="Screen Shot 2020-11-18 at 8 43 33 AM" src="https://user-images.githubusercontent.com/12522275/99590308-04637600-29a2-11eb-9d37-5c08a0d82fab.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
This is backwards compatible. There will be a visual change where now individual checkbox hover background will fill the entire formfield on hover.

#### How should this PR be communicated in the release notes?
Hover styling of individual CheckBox fills entire FormField.