### PR TITLE
Set default layer elevation to large

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -843,6 +843,9 @@ export const hpe = deepFreeze({
   },
   layer: {
     background: 'background',
+    container: {
+      elevation: 'large',
+    },
     overlay: {
       background: '#00000080',
     },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Sets Layer default elevation to large to match designs. Dependent on functionality currently only provided in grommet stable.

#### What testing has been done on this PR?
Tested locally in design system site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #149 

#### Screenshots (if appropriate)
<img width="1679" alt="Screen Shot 2021-01-05 at 1 36 29 PM" src="https://user-images.githubusercontent.com/12522275/103701686-4e58e900-4f5b-11eb-9a7a-3eb5ba5f00de.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible, but introduces new default elevation to align with Figma.

#### How should this PR be communicated in the release notes?
Layer applies elevation "large" by default.