### PR TITLE
Apply border radius to layer to match Figma

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -843,6 +843,10 @@ export const hpe = deepFreeze({
   },
   layer: {
     background: 'background',
+    border: {
+      radius: 'small',
+      intelligentRounding: true,
+    },
     container: {
       elevation: 'large',
     },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Apply border radius `small` to Layer and use `intelligentRounding` so that if the edge of a Layer is touching the edge of a screen (such as full Layer), there will not be rounding. Dependent on functionality that is currently only on grommet stable.

#### What testing has been done on this PR?
Tested local in site first.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1341

#### Screenshots (if appropriate)
<img width="1107" alt="Screen Shot 2021-01-26 at 5 12 38 PM" src="https://user-images.githubusercontent.com/12522275/105928001-fc573080-5ff9-11eb-8897-b8e6c51e3788.png">

<img width="1109" alt="Screen Shot 2021-01-26 at 5 12 55 PM" src="https://user-images.githubusercontent.com/12522275/105928014-011be480-5ffa-11eb-8262-2a8a6e7b4a26.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Aligns with Figma.

#### How should this PR be communicated in the release notes?
Layer border-radius updated to have value of `12px`.