### PR TITLE
Use text-strong for headings

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -700,6 +700,7 @@ export const hpe = deepFreeze({
     round: '4px',
   },
   heading: {
+    color: 'text-strong',
     level: {
       '1': {
         small: {
@@ -835,10 +836,6 @@ export const hpe = deepFreeze({
       },
     },
     weight: 700,
-    extend: ({ theme }) =>
-      `color: ${
-        theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
-      };`,
   },
   icon: {
     size: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -835,6 +835,10 @@ export const hpe = deepFreeze({
       },
     },
     weight: 700,
+    extend: ({ theme }) =>
+      `color: ${
+        theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
+      };`,
   },
   icon: {
     size: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates heading to use `text-strong` instead of `text`.

#### What testing has been done on this PR?

Tested locally in design system site first. See snapshots below.

#### Any background context you want to provide?

A design decision was made to use `text-strong` for headings by default.

#### What are the relevant issues?

Closes #152 

#### Screenshots (if appropriate)

Pulled these as some examples, for all snapshot tests, see: https://eyes.applitools.com/app/test-results/00000251790534341231?accountId=diU-zN8vi0mdpzHhZndu1A~~&display=details&top=00000251790534341231%2830%29

<img width="426" alt="Screen Shot 2021-01-27 at 9 16 39 AM" src="https://user-images.githubusercontent.com/12522275/106028474-d88afd80-6080-11eb-9b69-938ee82a3e0a.png">

Before:
<img width="428" alt="Screen Shot 2021-01-27 at 9 16 20 AM" src="https://user-images.githubusercontent.com/12522275/106028550-f22c4500-6080-11eb-8e0c-35a098d0af90.png">

After:
<img width="426" alt="Screen Shot 2021-01-27 at 9 16 26 AM" src="https://user-images.githubusercontent.com/12522275/106028573-f7898f80-6080-11eb-9864-3c0a4b9aef5b.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

New visual style.

#### How should this PR be communicated in the release notes?

Heading uses `text-strong` by default.