### PR TITLE
Set default card elevation to medium and fix elevation hex value

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -228,8 +228,8 @@ export const hpe = deepFreeze({
       // As defined here, default is currently mapping to medium.
       light: {
         small: '0px 2px 4px #0000001F;',
-        medium: '0px 6px 12px #0000003D;',
-        large: '0px 12px 24px #0000001F;',
+        medium: '0px 6px 12px #0000001F;',
+        large: '0px 12px 24px #0000003D;',
       },
       dark: {
         small: '0px 2px 4px #0000003D;',
@@ -450,6 +450,7 @@ export const hpe = deepFreeze({
   card: {
     container: {
       background: 'background-front',
+      elevation: 'medium',
     },
     body: {
       pad: 'medium',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Align Card default elevation to Figma with value of `medium`. Align elevation values to Figma. The HEX value for elevation.light.medium and elevation.light.dark had been reversed.

Card: https://www.figma.com/file/je5AYzMavRt1cG7rmw8j1W/HPE-Card-Component?node-id=1%3A2

Colors: https://www.figma.com/file/eZYR3dtWdb9U90QvJ7p3T9/HPE-Color-Styles?node-id=0%3A1

#### What testing has been done on this PR?
Tested locally in design system site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1376

#### Screenshots
<img width="437" alt="Screen Shot 2021-01-27 at 11 18 50 AM" src="https://user-images.githubusercontent.com/12522275/106042216-974f1980-6091-11eb-8eb0-95be688b13fb.png">

<img width="453" alt="Screen Shot 2021-01-27 at 11 19 27 AM" src="https://user-images.githubusercontent.com/12522275/106042213-961dec80-6091-11eb-823b-2b617ef05fca.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
New default elevation value, but aligns theme to Figma.

#### How should this PR be communicated in the release notes?
Card uses elevation `medium` by default.