### PR TITLE
Add back in gh pages release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           at: ~/grommet-ci
       - run:
           name: Build
-          command: yarn build
+          command: yarn build && yarn jsonify
       - persist_to_workspace:
           root: ~/grommet-ci
           paths:
@@ -53,6 +53,16 @@ jobs:
             git config --global user.name "Grommet Community Bot"
             git config --global user.email "grommet@hpe.com"
             yarn release-stable
+  release-gh-pages:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/grommet-ci
+      - run:
+          command: |
+            git config --global user.name "Grommet Community Bot"
+            git config --global user.email "grommet@hpe.com"
+            yarn release-gh-pages
   publish:
     <<: *defaults
     steps:
@@ -80,6 +90,7 @@ workflows:
             branches:
               ignore:
                 - stable
+                - gh-pages
       - build:
           requires:
             - checkout
@@ -89,7 +100,16 @@ workflows:
             branches:
               ignore:
                 - stable
+                - gh-pages
       - release-stable:
+          requires:
+            - lint
+            - build
+          filters:
+            branches:
+              only:
+                - master
+      - release-gh-pages:
           requires:
             - lint
             - build

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "webpack-cli": "^3.1.0"
   },
   "scripts": {
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && npm run jsonify",
     "build": "webpack --mode production && cross-env babel ./src/js/ --out-dir ./dist --copy-files && cross-env BABEL_ENV=es6 babel ./src/js/ --out-dir ./dist/es6 --copy-files",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -78,10 +78,7 @@ export const hpe = deepFreeze({
         light: '#BBBBBB',
       },
       control: 'green',
-      'active-background': {
-        dark: '#FFFFFF14',
-        light: '#0000000A',
-      },
+      'active-background': 'background-contrast',
       'active-text': 'text',
       'disabled-text': 'text-weak', // deprecated, use text-weak instead
       'selected-background': 'green',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -78,7 +78,10 @@ export const hpe = deepFreeze({
         light: '#BBBBBB',
       },
       control: 'green',
-      'active-background': 'background-contrast',
+      'active-background': {
+        dark: '#FFFFFF14',
+        light: '#0000000A',
+      },
       'active-text': 'text',
       'disabled-text': 'text-weak', // deprecated, use text-weak instead
       'selected-background': 'green',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
We had previously created release-github-pages to respond to NEXT branch, but that functionality was lost once we merged NEXT into master. This aims to publish the updated theme to github pages for use with grommet designer anytime there are changes.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
