### PR TITLE
Update tab styling for active state and padding

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1015,10 +1015,10 @@ export const hpe = deepFreeze({
         color: 'border-strong',
       },
       disabled: {
-        color: 'transparent',
+        color: undefined,
       },
       hover: {
-        color: 'transparent',
+        color: undefined,
       },
     },
     disabled: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1009,21 +1009,28 @@ export const hpe = deepFreeze({
     },
     border: {
       side: 'bottom',
-      color: 'border',
+      color: 'transparent',
+      size: 'medium',
       active: {
         color: 'border-strong',
       },
       disabled: {
-        color: 'border-weak',
+        color: 'transparent',
       },
       hover: {
-        color: 'border',
+        color: 'transparent',
       },
     },
     disabled: {
       color: 'text-weak',
     },
-    pad: 'small',
+    pad: {
+      // top and bottom pad need to be defined individually, specifying
+      // "vertical" only applies to top
+      bottom: 'small',
+      top: 'small',
+      horizontal: 'medium',
+    },
     margin: {
       // bring the overall tabs border behind invidual tab borders
       vertical: '-2px',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates tab styling for active state and increases horizontal padding to create better affinity between tab icon + label.

#### What testing has been done on this PR?
Tested locally in aries-site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #146 
Closes https://github.com/grommet/hpe-design-system/issues/1363
Closes https://github.com/grommet/hpe-design-system/issues/1385

#### Screenshots (if appropriate)
<img width="649" alt="Screen Shot 2021-02-01 at 9 39 45 AM" src="https://user-images.githubusercontent.com/12522275/106510204-7c124e80-6483-11eb-8226-c9e1629525a5.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

Introduces new tab styling.

#### How should this PR be communicated in the release notes?
Active tabs have a "medium" width border of border-strong and increased horizontal padding from "small" to "medium".