### PR TITLE
Display * next to label of required FormField

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -693,6 +693,7 @@ export const hpe = deepFreeze({
         top: 'xsmall',
         horizontal: 'none',
       },
+      requiredIndicator: true,
       weight: 500,
     },
     margin: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Display an * next to required formfield labels. Once this merges, we will need to remove custom label components in the design system site that had been providing the *

#### What testing has been done on this PR?
Tested local in design-system site.

#### Any background context you want to provide?
Design decision backed by this best practice: https://www.nngroup.com/articles/required-fields/

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="485" alt="Screen Shot 2021-02-05 at 11 23 03 AM" src="https://user-images.githubusercontent.com/12522275/107079863-5055d800-67a5-11eb-8d30-6e071ed48aa4.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Introduces new visual change.

#### How should this PR be communicated in the release notes?
Added asterisk * next to required FormField labels. 