### PR TITLE
Removed the button kind paddings as part of fix for button sizing #139

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -281,10 +281,6 @@ export const hpe = deepFreeze({
       font: {
         weight: 700,
       },
-      padding: {
-        horizontal: '12px',
-        vertical: '6px',
-      },
     },
     primary: {
       background: {
@@ -294,10 +290,6 @@ export const hpe = deepFreeze({
       color: 'text-strong',
       font: {
         weight: 700,
-      },
-      padding: {
-        horizontal: '12px',
-        vertical: '6px',
       },
     },
     secondary: {
@@ -309,19 +301,11 @@ export const hpe = deepFreeze({
       font: {
         weight: 700,
       },
-      padding: {
-        horizontal: '10px',
-        vertical: '4px',
-      },
     },
     option: {
       color: 'text',
       border: {
         radius: '0px',
-      },
-      padding: {
-        horizontal: '12px',
-        vertical: '6px',
       },
       font: {
         weight: 400,
@@ -359,10 +343,6 @@ export const hpe = deepFreeze({
           color: 'border-weak',
           width: '2px',
         },
-        padding: {
-          horizontal: '10px',
-          vertical: '4px',
-        },
       },
       secondary: {
         border: {
@@ -381,10 +361,6 @@ export const hpe = deepFreeze({
       secondary: {
         border: {
           width: '3px',
-        },
-        padding: {
-          horizontal: '9px',
-          vertical: '3px',
         },
       },
       option: {


### PR DESCRIPTION
#### What does this PR do?
Removes the padding overrides in the button 'kind'-specific parts of the
theme and allows the button 'size' part of the theme to specify them.
Grommet v2.16.3 correctly adjusts the padding to account for any borders
added by the 'kind' styles, avoiding the need to have kind-specific padding.

#### What testing has been done on this PR?
Tested in grommet with this theme.

#### Any background context you want to provide?

#### What are the relevant issues?
Fixes #139

#### Screenshots (if appropriate)
Before theme fixes:
![image](https://user-images.githubusercontent.com/12054362/107708468-c6b07980-6c80-11eb-821f-68eb8d0627d5.png)

After theme fixes:
![image](https://user-images.githubusercontent.com/12054362/107707027-7df7c100-6c7e-11eb-81f7-98499f292ebc.png)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible.

#### How should this PR be communicated in the release notes?
Can mention that button sizes now work correctly with this theme