### PR TITLE
Update button medium pad

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -383,8 +383,8 @@ export const hpe = deepFreeze({
           radius: '4px',
         },
         pad: {
-          vertical: '4px',
-          horizontal: '10px',
+          vertical: '6px',
+          horizontal: '12px',
         },
       },
       large: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Button size medium should have horizontal pad `12px` and vertical pad `6px`. When we removed the kind specific padding, we lost this styling.

Total height of default button should be 36px. https://www.figma.com/file/Oi5UEEQ33VCAyOKQcZ8Nr8/HPE-Button-Component?node-id=0%3A1

#### What testing has been done on this PR?
Test local in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

Currently (Default/Medium button have improper dimensions):
<img width="439" alt="Screen Shot 2021-02-18 at 1 50 32 PM" src="https://user-images.githubusercontent.com/12522275/108428900-22848080-71f4-11eb-8319-7ceaf8615ebe.png">

With correction (Default/medium correct dimension of 36px tall):
<img width="458" alt="Screen Shot 2021-02-18 at 1 49 59 PM" src="https://user-images.githubusercontent.com/12522275/108428868-18628200-71f4-11eb-85bf-1f7c6ceffa39.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
