### PR TITLE
add tooltip

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1123,6 +1123,7 @@ export const hpe = deepFreeze({
       border: {
         color: 'border-weak',
       },
+      margin: 'xxsmall',
       elevation: 'small',
       pad: {
         vertical: 'none',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1119,6 +1119,7 @@ export const hpe = deepFreeze({
   },
   tip: {
     content: {
+      margin: 'xxsmall',
       background: 'background',
       border: {
         color: 'border-weak',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1119,7 +1119,6 @@ export const hpe = deepFreeze({
   },
   tip: {
     content: {
-      margin: 'xxsmall',
       background: 'background',
       border: {
         color: 'border-weak',

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1117,6 +1117,20 @@ export const hpe = deepFreeze({
       `,
     },
   },
+  tip: {
+    content: {
+      background: 'background',
+      border: {
+        color: 'border-weak',
+      },
+      elevation: 'small',
+      pad: {
+        vertical: 'none',
+        horizontal: 'small',
+      },
+      round: 'xsmall',
+    },
+  },
   // Theme-Designer only parameters
   name: 'HPE 1',
   rounding: 4,


### PR DESCRIPTION
Add the tooltip theme to match the designs.

Currently, the designs call for  `medium` elevation. However, it does not look correct with the medium so  I replaced it with small and will follow up on an issue. 

With medium, the bottom shadow is very harsh. 
<img width="571" alt="Screen Shot 2021-02-22 at 11 50 34 AM" src="https://user-images.githubusercontent.com/42451602/108755192-2d952480-7504-11eb-9ddf-398d68b95d59.png">
