### PR TITLE
Set default menu drop alignment

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -861,6 +861,12 @@ export const hpe = deepFreeze({
     },
   },
   menu: {
+    drop: {
+      align: {
+        top: 'bottom',
+        left: 'left',
+      },
+    },
     icons: {
       color: 'text-strong',
     },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Aligns Menu drop with [Figma](https://www.figma.com/file/DyFWlzLBUtK5KH5jJhwoCB/HPE-Menu-Component?node-id=0%3A1) where drop should be aligned `{ top: 'bottom', left: 'left' }`
 
#### What testing has been done on this PR?
Tested local in design system site

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1416

#### Screenshots (if appropriate)
<img width="338" alt="Screen Shot 2021-03-03 at 9 59 20 AM" src="https://user-images.githubusercontent.com/12522275/109851122-26f36500-7c08-11eb-853d-441a558c79fd.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
New drop alignment.

#### How should this PR be communicated in the release notes?
Aligned Menu's Drop alignment with Figma. Drop appears below the control button.