### PR TITLE
clean up drop margin

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -223,10 +223,8 @@ export const hpe = deepFreeze({
       border: {
         radius: '4px',
       },
-      extend: ({ alignProp, theme }) => `
-        margin-top: ${alignProp.top !== 'top' && theme.global.edgeSize.xsmall}; 
-        margin-bottom: ${alignProp.bottom !== 'bottom' &&
-          theme.global.edgeSize.xsmall}`,
+      margin: 'xsmall',
+      intelligentMargin: true,
       shadowSize: 'medium',
     },
     elevation: {


### PR DESCRIPTION
use new intelligent margin from grommet

<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds `intelligent margin` to theme both `search` and `tooltip` are `xsmall` margin and now with the new `intelligent margin` the side in which the margin is placed is accurate.
#### What testing has been done on this PR?
design system local theme

```
  global: {
    drop: {
      margin: 'xsmall',
      intelligentMargin: true,
      background: 'background-front',
      border: {
        radius: '4px',
      },
      extend: () => {},
    },
  },

```
#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/1449
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backward compatible
#### How should this PR be communicated in the release notes?
