### PR TITLE
Adjust Layer z-index to sit atop HPE global header

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -838,6 +838,10 @@ export const hpe = deepFreeze({
     overlay: {
       background: '#00000080',
     },
+    /* HPE Global Header/Footer Service a.k.a. HPE Common HFWS sets the header
+     * at a z-index of 101. This adjustment allows for Layer modals and side-drawers
+     * to sit atop the Global header. */
+    zIndex: '110',
   },
   list: {
     item: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Closes https://github.com/grommet/grommet-theme-hpe/issues/184

#### What testing has been done on this PR?

Local project implementation with the Global header service.

#### Any background context you want to provide?

https://github.com/grommet/grommet-theme-hpe/issues/184

#### What are the relevant issues?

https://github.com/grommet/grommet-theme-hpe/issues/184

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

bc

#### How should this PR be communicated in the release notes?
