### PR TITLE
Align Drop and Layer zIndex

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -226,6 +226,10 @@ export const hpe = deepFreeze({
       margin: 'xsmall',
       intelligentMargin: true,
       shadowSize: 'medium',
+      /* HPE Global Header/Footer Service a.k.a. HPE Common HFWS sets the header
+       * at a z-index of 101. This adjustment brings Drop in alignment with Layer
+       * which needs an elevated z-index to sit atop the Global header. */
+      zIndex: '110',
     },
     elevation: {
       // Elevation values were derived from this Figma file.


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Closes https://github.com/grommet/grommet-theme-hpe/issues/187

#### What testing has been done on this PR?

Tested locally with `<Select />` within a `<Layer />`. However, I think we should do more exhaustive testing to check for edge cases and different combinations of components presented in a Layer.

I could use help brainstorming any other potential areas which might have unintended side effects do to the increased zIndex.

Since we are trying to release the theme, we may want to revert https://github.com/grommet/grommet-theme-hpe/pull/185, then use this implementation in another project to test on the side over an extended period of time.

#### Any background context you want to provide?

Originally trying to solve for the HPE Global Header Service which has a `z-index` of 101 and prevents Layer from filling window properly.

#### What are the relevant issues?

 https://github.com/grommet/grommet-theme-hpe/issues/184
https://github.com/grommet/grommet-theme-hpe/issues/187

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
