### PR TITLE
Add FileInput styling

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -7,6 +7,7 @@ import { CircleAlert } from 'grommet-icons/icons/CircleAlert';
 import { Descending } from 'grommet-icons/icons/Descending';
 import { FormDown } from 'grommet-icons/icons/FormDown';
 import { FormUp } from 'grommet-icons/icons/FormUp';
+import { Trash } from 'grommet-icons/icons/Trash';
 import { Unsorted } from 'grommet-icons/icons/Unsorted';
 
 const isObject = item =>
@@ -612,6 +613,44 @@ export const hpe = deepFreeze({
     icon: {
       size: 'small',
     },
+  },
+  fileInput: {
+    border: {
+      size: 'xsmall',
+    },
+    button: {
+      border: {
+        radius: '4px',
+      },
+      pad: {
+        vertical: '6px',
+        horizontal: '12px',
+      },
+      color: 'text-strong',
+      font: {
+        weight: 'bold',
+      },
+      hover: {
+        background: 'background-contrast',
+      },
+    },
+    dragOver: {
+      background: 'background-contrast',
+      border: 'none',
+    },
+    hover: {
+      border: {
+        color: 'border',
+      },
+    },
+    icons: {
+      remove: Trash,
+    },
+    message: {
+      color: 'text-weak',
+    },
+    pad: { horizontal: 'xsmall' },
+    extend: 'border-radius: 4px;',
   },
   formField: {
     content: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds FileInput styling per Figma Designs https://www.figma.com/file/8HwAiiSDloOTjUxqvCTypq/HPE-FileInput-Component?node-id=218%3A45549

#### What testing has been done on this PR?
Tested in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
(mouse was hovering over "Select File" button)
<img width="429" alt="Screen Shot 2021-05-24 at 4 55 31 PM" src="https://user-images.githubusercontent.com/12522275/119420380-3804bd00-bcb1-11eb-982d-869613c0003d.png">

<img width="433" alt="Screen Shot 2021-05-24 at 4 55 41 PM" src="https://user-images.githubusercontent.com/12522275/119420387-39ce8080-bcb1-11eb-9739-7aea6c4de1cb.png">

<img width="431" alt="Screen Shot 2021-05-24 at 4 55 52 PM" src="https://user-images.githubusercontent.com/12522275/119420391-3c30da80-bcb1-11eb-869b-2c610346a748.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible.

#### How should this PR be communicated in the release notes?
Added FileInput styling.