### PR TITLE
Add toolbar button kind

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -313,6 +313,16 @@ export const hpe = deepFreeze({
         weight: 700,
       },
     },
+    toolbar: {
+      border: {
+        color: 'border',
+        width: '1px',
+      },
+      color: 'text-strong',
+      font: {
+        weight: 700,
+      },
+    },
     option: {
       color: 'text',
       border: {
@@ -377,6 +387,9 @@ export const hpe = deepFreeze({
       option: {
         background: 'active-background',
         color: 'active-text',
+      },
+      toolbar: {
+        background: 'transparent',
       },
     },
     size: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This adds a button kind `toolbar` for the button kind featured below. Currently, this kind of button is always used in a toolbar context where it is inline with inputs such as a Search and the desire is that it has equal prominence as its peers.

#### What testing has been done on this PR?
Test in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1118

#### Screenshots (if appropriate)

<img width="71" alt="Screen Shot 2021-05-25 at 10 58 45 AM" src="https://user-images.githubusercontent.com/12522275/119545932-320deb00-bd48-11eb-94e8-02b5a65435fa.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible.

#### How should this PR be communicated in the release notes?
Added `toolbar` button kind.