### PR TITLE
Keep text-strong color on hover

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -390,6 +390,7 @@ export const hpe = deepFreeze({
       },
       toolbar: {
         background: 'transparent',
+        color: undefined,
       },
     },
     size: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Need to set hover color to undefined to ensure color stays as text-strong on hover. Mirroring what is done on default button.

#### What testing has been done on this PR?
Tested locally in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible.

#### How should this PR be communicated in the release notes?
no.
