### PR TITLE
Update accordion border color to match Figma

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -261,7 +261,7 @@ export const hpe = deepFreeze({
     panel: {
       border: {
         side: 'horizontal',
-        color: 'text',
+        color: 'border',
       },
     },
     heading: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Figma calls for color of `border` for Accordion. Updating to match.

#### What testing has been done on this PR?
In DS site.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="840" alt="Screen Shot 2021-07-01 at 4 47 50 PM" src="https://user-images.githubusercontent.com/12522275/124201219-4f8f4c80-da8c-11eb-8fe5-cc8abb752a06.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Aligning to Figma.

#### How should this PR be communicated in the release notes?
Fixed Accordion border color to align with Figma.