### PR TITLE
Update Calendar Icons

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,6 +6,8 @@ import { Blank } from 'grommet-icons/icons/Blank';
 import { CircleAlert } from 'grommet-icons/icons/CircleAlert';
 import { Descending } from 'grommet-icons/icons/Descending';
 import { FormDown } from 'grommet-icons/icons/FormDown';
+import { FormNext } from 'grommet-icons/icons/FormNext';
+import { FormPrevious } from 'grommet-icons/icons/FormPrevious';
 import { FormUp } from 'grommet-icons/icons/FormUp';
 import { Trash } from 'grommet-icons/icons/Trash';
 import { Unsorted } from 'grommet-icons/icons/Unsorted';
@@ -432,6 +434,10 @@ export const hpe = deepFreeze({
     },
   },
   calendar: {
+    icons: {
+      next: FormNext,
+      previous: FormPrevious,
+    },
     small: {
       fontSize: '13.6px',
       lineHeight: 1.375,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Figma calls for `FormNext` and `FormPrevious` in Calendar on all viewport sizes. Updating to match.

#### What testing has been done on this PR?
Local in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/issues/1676

#### Screenshots (if appropriate)
<img width="476" alt="Screen Shot 2021-07-02 at 7 46 41 AM" src="https://user-images.githubusercontent.com/12522275/124292139-1bf30780-db0a-11eb-8d0f-b4950db170a4.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
New icons, but just smaller.

#### How should this PR be communicated in the release notes?
Fixed Calendar icons to use FormNext and FormPrevious to match Figma.