### PR TITLE
add alternative background for Firefox 

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -602,21 +602,30 @@ export const hpe = deepFreeze({
           color: 'background-front',
           opacity: 'strong',
         },
-        extend: 'backdrop-filter: blur(8px);',
+        extend: `backdrop-filter: blur(8px);
+        @-moz-document url-prefix() {
+          background-color: rgba(255, 255, 255, 0.92);
+      }`,
       },
       body: {
         background: {
           color: 'background-front',
           opacity: 'strong',
         },
-        extend: 'backdrop-filter: blur(8px);',
+        extend: `backdrop-filter: blur(8px);
+        @-moz-document url-prefix() {
+          background-color: rgba(255, 255, 255, 0.92);
+      }`,
       },
       footer: {
         background: {
           color: 'background-front',
           opacity: 'strong',
         },
-        extend: 'backdrop-filter: blur(8px);',
+        extend: `backdrop-filter: blur(8px);
+        @-moz-document url-prefix() {
+          background-color: rgba(255, 255, 255, 0.92);
+      }`,
       },
     },
     resize: {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -596,15 +596,19 @@ export const hpe = deepFreeze({
       descending: Descending,
       sortable: Unsorted,
     },
+    /* Add FireFox work around until it adds support for backdrop-filter
+    https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter
+    */
     pinned: {
       header: {
         background: {
           color: 'background-front',
           opacity: 'strong',
         },
-        extend: `backdrop-filter: blur(8px);
+        extend: ({ theme }) => `backdrop-filter: blur(8px);
         @-moz-document url-prefix() {
-          background-color: rgba(255, 255, 255, 0.92);
+          background: ${theme.dark ? '#404b5cF2' : '#ffffffF2'};
+          }
       }`,
       },
       body: {
@@ -612,9 +616,10 @@ export const hpe = deepFreeze({
           color: 'background-front',
           opacity: 'strong',
         },
-        extend: `backdrop-filter: blur(8px);
+        extend: ({ theme }) => `backdrop-filter: blur(8px);
         @-moz-document url-prefix() {
-          background-color: rgba(255, 255, 255, 0.92);
+          background: ${theme.dark ? '#404b5cF2' : '#ffffffF2'};
+          }
       }`,
       },
       footer: {
@@ -622,9 +627,10 @@ export const hpe = deepFreeze({
           color: 'background-front',
           opacity: 'strong',
         },
-        extend: `backdrop-filter: blur(8px);
+        extend: ({ theme }) => `backdrop-filter: blur(8px);
         @-moz-document url-prefix() {
-          background-color: rgba(255, 255, 255, 0.92);
+          background: ${theme.dark ? '#404b5cF2' : '#ffffffF2'};
+          }
       }`,
       },
     },

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -605,6 +605,7 @@ export const hpe = deepFreeze({
           color: 'background-front',
           opacity: 'strong',
         },
+        // values for background are same as 'background-front' set to a 95% opacity
         extend: ({ theme }) => `backdrop-filter: blur(8px);
         @-moz-document url-prefix() {
           background: ${theme.dark ? '#404b5cF2' : '#ffffffF2'};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds a background that has a opacity for `datatable` for just FireFox browser
#### What testing has been done on this PR?
Browser
#### Any background context you want to provide?
We were using  `backdrop-filter: blur(8px)` however FireFox does not support `backdrop-filter:`
so as an alternative I thought adding a background will at least make the `datatable` more readable 
#### What are the relevant issues?
closes issue #200 
#### Screenshots (if appropriate)
Currently looks like this below: 
<img width="1021" alt="Screen Shot 2021-08-04 at 9 24 09 PM" src="https://user-images.githubusercontent.com/42451602/128285933-14da9998-2e33-4390-b23a-6fe2a00c440d.png">
<img width="1024" alt="Screen Shot 2021-08-04 at 9 24 22 PM" src="https://user-images.githubusercontent.com/42451602/128285955-e38d8afc-8af7-4bb5-9235-626198d2137f.png">

With the background:
Does not have that nice effect as chrome but at least now its much easier to read:

<img width="1024" alt="Screen Shot 2021-08-04 at 9 25 43 PM" src="https://user-images.githubusercontent.com/42451602/128286043-b24fafc5-ce54-4a6c-9a48-be1a0e30b134.png">
<img width="1025" alt="Screen Shot 2021-08-04 at 9 25 58 PM" src="https://user-images.githubusercontent.com/42451602/128286067-1eb0f5e8-2d63-46e4-b373-607944b90e83.png">

In Chrome:

<img width="880" alt="Screen Shot 2021-08-04 at 9 26 56 PM" src="https://user-images.githubusercontent.com/42451602/128286174-f24d4981-7576-4b09-acc8-2471c133df55.png">


#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backward compatible
#### How should this PR be communicated in the release notes?
sure
