### PR TITLE
change the padding to take into account the border

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -164,8 +164,8 @@ export const hpe = deepFreeze({
         weight: 500,
       },
       padding: {
-        horizontal: 'small',
-        vertical: 'xsmall',
+        horizontal: '11px',
+        vertical: '5px',
       },
       extend: `
         &::-webkit-input-placeholder {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -164,7 +164,7 @@ export const hpe = deepFreeze({
         weight: 500,
       },
       padding: {
-        horizontal: '11px',
+        horizontal: '11px', // equivalent to 'small' when combined with 1px border
         vertical: '5px', // equivalent to 'small' when combined with 1px border
       },
       extend: `

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -165,7 +165,7 @@ export const hpe = deepFreeze({
       },
       padding: {
         horizontal: '11px', // equivalent to 'small' when combined with 1px border
-        vertical: '5px', // equivalent to 'small' when combined with 1px border
+        vertical: '5px', // equivalent to 'xsmall' when combined with 1px border
       },
       extend: `
         &::-webkit-input-placeholder {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -165,7 +165,7 @@ export const hpe = deepFreeze({
       },
       padding: {
         horizontal: '11px',
-        vertical: '5px',
+        vertical: '5px', // equivalent to 'small' when combined with 1px border
       },
       extend: `
         &::-webkit-input-placeholder {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR changes the padding for the `input` this takes into account the border for the inputs. The size of the `textinput` without being wrapped in a `formfield` is `38px` with wrapping it in a `formfield` then it uses the `textinput` plain so without the border and is then the correct size.
#### What testing has been done on this PR?
in the design system site
#### Any background context you want to provide?
Below is a picture of the sizes for `button` the padding is off by one to account for the border. I believe we need to do the same for the `inputs` as well. Since `Select` and  `Menu` are made from `button` their sizes are correct. 
<img width="232" alt="Screen Shot 2021-09-08 at 3 59 25 PM" src="https://user-images.githubusercontent.com/42451602/132591363-287875b8-a101-47fb-b966-940b29a29b9b.png">

With this change to the padding you can see that they both will match up correctly. 
<img width="554" alt="Screen Shot 2021-09-08 at 4 02 00 PM" src="https://user-images.githubusercontent.com/42451602/132591616-5c314ad4-5f41-4d69-a654-fc112179055e.png">

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/1778
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backward compatible
#### How should this PR be communicated in the release notes?
