### PR TITLE
Update pinned DataTable background

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -12,12 +12,12 @@ import { FormUp } from 'grommet-icons/icons/FormUp';
 import { FormTrash } from 'grommet-icons/icons/FormTrash';
 import { Unsorted } from 'grommet-icons/icons/Unsorted';
 
-const isObject = item =>
+const isObject = (item) =>
   item && typeof item === 'object' && !Array.isArray(item);
 
-const deepFreeze = obj => {
+const deepFreeze = (obj) => {
   Object.keys(obj).forEach(
-    key => key && isObject(obj[key]) && Object.freeze(obj[key]),
+    (key) => key && isObject(obj[key]) && Object.freeze(obj[key]),
   );
   return Object.freeze(obj);
 };
@@ -517,21 +517,25 @@ export const hpe = deepFreeze({
         `,
       },
       extend: ({ checked, theme }) => `
-        ${checked &&
+        ${
+          checked &&
           `background-color: ${
             theme.global.colors.green[theme.dark ? 'dark' : 'light']
-          };`}
+          };`
+        }
       `,
     },
     extend: ({ disabled, theme }) => `
-      ${!disabled &&
+      ${
+        !disabled &&
         `:hover {
         background-color: ${
           theme.global.colors['background-contrast'][
             theme.dark ? 'dark' : 'light'
           ]
         };
-      }`}
+      }`
+      }
       font-weight: 500;
       width: auto;
       padding: ${theme.global.edgeSize.xsmall} ${theme.global.edgeSize.small};
@@ -558,7 +562,8 @@ export const hpe = deepFreeze({
       color: 'text-strong',
       extend: ({ column, sort, sortable, theme }) =>
         `
-          ${sort &&
+          ${
+            sort &&
             sort.property === column &&
             `
             background: ${
@@ -566,8 +571,10 @@ export const hpe = deepFreeze({
                 theme.dark ? 'dark' : 'light'
               ]
             }
-          `};
-          ${sortable &&
+          `
+          };
+          ${
+            sortable &&
             sort &&
             sort.property !== column &&
             `
@@ -579,7 +586,8 @@ export const hpe = deepFreeze({
                   opacity: 1;
                 }
               }
-            `};
+            `
+          };
         `,
       font: {
         weight: 'bold',
@@ -1044,7 +1052,7 @@ export const hpe = deepFreeze({
     control: {
       extend: ({ disabled }) => css`
         ${disabled &&
-          `
+        `
         opacity: 0.3;
         input {
           cursor: default;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -12,12 +12,12 @@ import { FormUp } from 'grommet-icons/icons/FormUp';
 import { FormTrash } from 'grommet-icons/icons/FormTrash';
 import { Unsorted } from 'grommet-icons/icons/Unsorted';
 
-const isObject = (item) =>
+const isObject = item =>
   item && typeof item === 'object' && !Array.isArray(item);
 
-const deepFreeze = (obj) => {
+const deepFreeze = obj => {
   Object.keys(obj).forEach(
-    (key) => key && isObject(obj[key]) && Object.freeze(obj[key]),
+    key => key && isObject(obj[key]) && Object.freeze(obj[key]),
   );
   return Object.freeze(obj);
 };
@@ -517,25 +517,21 @@ export const hpe = deepFreeze({
         `,
       },
       extend: ({ checked, theme }) => `
-        ${
-          checked &&
+        ${checked &&
           `background-color: ${
             theme.global.colors.green[theme.dark ? 'dark' : 'light']
-          };`
-        }
+          };`}
       `,
     },
     extend: ({ disabled, theme }) => `
-      ${
-        !disabled &&
+      ${!disabled &&
         `:hover {
         background-color: ${
           theme.global.colors['background-contrast'][
             theme.dark ? 'dark' : 'light'
           ]
         };
-      }`
-      }
+      }`}
       font-weight: 500;
       width: auto;
       padding: ${theme.global.edgeSize.xsmall} ${theme.global.edgeSize.small};
@@ -562,8 +558,7 @@ export const hpe = deepFreeze({
       color: 'text-strong',
       extend: ({ column, sort, sortable, theme }) =>
         `
-          ${
-            sort &&
+          ${sort &&
             sort.property === column &&
             `
             background: ${
@@ -571,10 +566,8 @@ export const hpe = deepFreeze({
                 theme.dark ? 'dark' : 'light'
               ]
             }
-          `
-          };
-          ${
-            sortable &&
+          `};
+          ${sortable &&
             sort &&
             sort.property !== column &&
             `
@@ -586,8 +579,7 @@ export const hpe = deepFreeze({
                   opacity: 1;
                 }
               }
-            `
-          };
+            `};
         `,
       font: {
         weight: 'bold',
@@ -610,38 +602,16 @@ export const hpe = deepFreeze({
     */
     pinned: {
       header: {
-        background: {
-          color: 'background-front',
-          opacity: 'strong',
-        },
-        // values for background are same as 'background-front' set to a 95% opacity
-        extend: ({ theme }) => `backdrop-filter: blur(8px);
-        @-moz-document url-prefix() {
-          background: ${theme.dark ? '#404b5cF2' : '#ffffffF2'};
-          }
-      }`,
+        background: { opacity: 0.95 },
+        extend: 'backdrop-filter: blur(8px);',
       },
       body: {
-        background: {
-          color: 'background-front',
-          opacity: 'strong',
-        },
-        extend: ({ theme }) => `backdrop-filter: blur(8px);
-        @-moz-document url-prefix() {
-          background: ${theme.dark ? '#404b5cF2' : '#ffffffF2'};
-          }
-      }`,
+        background: { opacity: 0.95 },
+        extend: 'backdrop-filter: blur(8px);',
       },
       footer: {
-        background: {
-          color: 'background-front',
-          opacity: 'strong',
-        },
-        extend: ({ theme }) => `backdrop-filter: blur(8px);
-        @-moz-document url-prefix() {
-          background: ${theme.dark ? '#404b5cF2' : '#ffffffF2'};
-          }
-      }`,
+        background: { opacity: 0.95 },
+        extend: 'backdrop-filter: blur(8px);',
       },
     },
     resize: {
@@ -1074,7 +1044,7 @@ export const hpe = deepFreeze({
     control: {
       extend: ({ disabled }) => css`
         ${disabled &&
-        `
+          `
         opacity: 0.3;
         input {
           cursor: default;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Leverages Grommet's more recent intelligent background for datatable pinned cells. Thus we can remove the "background-front" declaration and let the datatable be smart about what background it's on.

Updating the opacity from 'strong' to 0.95 so it works for all browsers (Firefox included). This does make the blur slightly less apparent in Chrome but I think the difference is minimal and creates a more readable table.

#### What testing has been done on this PR?
Tested locally in DS Site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #206 

#### Screenshots (if appropriate)

Note: these are static images, the blur is more visible when user is actually scrolling.

<img width="409" alt="Screen Shot 2021-09-15 at 1 54 27 PM" src="https://user-images.githubusercontent.com/12522275/133508170-5c47c659-2637-4da3-a352-47a6cf9eb078.png">
<img width="411" alt="Screen Shot 2021-09-15 at 1 54 05 PM" src="https://user-images.githubusercontent.com/12522275/133508176-a4be34a0-2804-480c-a3ad-56cb5e7269dd.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

Makes the opacity on the pinned cells from 0.8 --> 0.95 but fixes incorrect color treatment/makes behavior more consistent from firefox to chrome and other browsers.

#### How should this PR be communicated in the release notes?
- Fixed pinned DataTable background color