### PR TITLE
align theme with figma file for rangeinput

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1026,15 +1026,7 @@ export const hpe = deepFreeze({
   },
   rangeInput: {
     thumb: {
-      color: 'background',
-      extend: ({ theme }) => `
-        border: 1px solid ${
-          theme.global.colors.border[theme.dark ? 'dark' : 'light']
-        };
-        box-shadow: ${
-          theme.global.elevation[theme.dark ? 'dark' : 'light'].small
-        };
-      `,
+      color: 'green',
     },
     track: {
       lower: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR  aligns RangeInput with the [Figma file](https://www.figma.com/file/BqCjvjc0rECQ4Ln2QhyjNi/HPE-Range-Input-Component?node-id=0%3A1)

#### What testing has been done on this PR?
aries-site
#### Any background context you want to provide?
RangeInput was the color of `background` before with a `border` on hover which was hard to see so the designs were changed to align more with grommet.
#### What are the relevant issues?
closes #1892
in design system
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
yes