### PR TITLE
Added dark and light code block themes

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1233,3 +1233,253 @@ export const hpe = deepFreeze({
 });
 
 export const { colors } = hpe.global;
+
+export const DarkCodeTheme = {
+  'code[class*="language-"]': {
+      'color': colors.text.dark,
+      'background': 'none',
+      'textAlign': 'left',
+      'whiteSpace': 'pre',
+      'wordSpacing': 'normal',
+      'wordBreak': 'normal',
+      'wordWrap': 'normal',
+      'lineHeight': '1.5',
+      'MozTabSize': '4',
+      'OTabSize': '4',
+      'tabSize': '4',
+      'WebkitHyphens': 'none',
+      'MozHyphens': 'none',
+      'msHyphens': 'none',
+      'hyphens': 'none',
+  },
+  'pre[class*="language-"]': {
+      'color': colors.text.dark,
+      'background': 'black',
+      'textAlign': 'left',
+      'whiteSpace': 'pre',
+      'wordSpacing': 'normal',
+      'wordBreak': 'normal',
+      'wordWrap': 'normal',
+      'lineHeight': '1.5',
+      'MozTabSize': '4',
+      'OTabSize': '4',
+      'tabSize': '4',
+      'WebkitHyphens': 'none',
+      'MozHyphens': 'none',
+      'msHyphens': 'none',
+      'hyphens': 'none',
+      'padding': '1em',
+      'margin': '0.5em 0',
+      'overflow': 'auto',
+      'borderRadius': '0.3em',
+  },
+  ':not(pre) > code[class*="language-"]': {
+      'background': 'black',
+      'padding': '0.1em',
+      'borderRadius': '0.3em',
+      'whiteSpace': 'normal',
+  },
+  'class-name': {
+      'color': colors['status-critical'].light,
+  },
+  'maybe-class-name': {
+      'color': colors.purple.light,
+  },
+  'comment': {
+      'color': colors['status-unknown'].light,
+  },
+  'function': {
+      'color': colors['status-critical'].light,
+  },
+  'operator': {
+      'color': colors.orange.light,
+  },
+  'string': {
+      'color': colors['teal!'],
+  },
+  'boolean': {
+      'color': colors['teal!'],
+  },
+  'number': {
+      'color': colors['teal!'],
+  },
+  'keyword': {
+      'color': colors.blue.light,
+  },
+
+  'selector': {
+      'color': colors['teal!'],
+  },
+  'attr-name': {
+      'color': colors['teal!'],
+  },
+  'char': {
+      'color': colors['teal!'],
+  },
+  'builtin': {
+      'color': colors['teal!'],
+  },
+  'inserted': {
+      'color': colors['teal!'],
+  },
+  'entity': {
+      'color': colors.blue.light,
+      'cursor': 'help',
+  },
+  'url': {
+      'color': colors.blue.light,
+  },
+  '.language-css .token.string': {
+      'color': colors.blue.light,
+  },
+  '.style .token.string': {
+      'color': colors.blue.light,
+  },
+  'variable': {
+      'color': colors.blue.light,
+  },
+  'atrule': {
+      'color': colors.orange.light,
+  },
+  'attr-value': {
+      'color': colors.orange.light,
+  },
+  
+  'regex': {
+      'color': colors.orange.light,
+  },
+  'important': {
+      'color': colors.orange.light,
+      'fontWeight': 'bold',
+  },
+  'bold': {
+      'fontWeight': 'bold',
+  },
+  'italic': {
+      'fontStyle': 'italic',
+  },
+};
+
+export const LightCodeTheme = {
+  'code[class*="language-"]': {
+      'color': colors.text.light,
+      'background': 'none',
+      'textAlign': 'left',
+      'whiteSpace': 'pre',
+      'wordSpacing': 'normal',
+      'wordBreak': 'normal',
+      'wordWrap': 'normal',
+      'lineHeight': '1.5',
+      'MozTabSize': '4',
+      'OTabSize': '4',
+      'tabSize': '4',
+      'WebkitHyphens': 'none',
+      'MozHyphens': 'none',
+      'msHyphens': 'none',
+      'hyphens': 'none',
+  },
+  'pre[class*="language-"]': {
+      'color': colors.text.light,
+      'background': colors['background-contrast'].light,
+      'textAlign': 'left',
+      'whiteSpace': 'pre',
+      'wordSpacing': 'normal',
+      'wordBreak': 'normal',
+      'wordWrap': 'normal',
+      'lineHeight': '1.5',
+      'MozTabSize': '4',
+      'OTabSize': '4',
+      'tabSize': '4',
+      'WebkitHyphens': 'none',
+      'MozHyphens': 'none',
+      'msHyphens': 'none',
+      'hyphens': 'none',
+      'padding': '1em',
+      'margin': '0.5em 0',
+      'overflow': 'auto',
+      'borderRadius': '0.3em',
+  },
+  ':not(pre) > code[class*="language-"]': {
+      'background': colors['background-contrast'].light,
+      'padding': '0.1em',
+      'borderRadius': '0.3em',
+      'whiteSpace': 'normal',
+  },
+  'class-name': {
+      'color': colors.red.dark,
+  },
+  'maybe-class-name': {
+      'color': colors['purple!'],
+  },
+  'comment': {
+      'color': colors['status-unknown'].dark,
+  },
+  'function': {
+      'color': colors.red.dark,
+  },
+  'operator': {
+      'color': colors.orange.dark,
+  },
+  'string': {
+      'color': colors.teal.dark,
+  },
+  'boolean': {
+      'color': colors.teal.dark,
+  },
+  'number': {
+      'color': colors.teal.dark,
+  },
+  'keyword': {
+      'color': colors.blue.dark,
+  },
+  'selector': {
+      'color': colors.teal.dark,
+  },
+  'attr-name': {
+      'color': colors.teal.dark,
+  },
+  'char': {
+      'color': colors.teal.dark,
+  },
+  'builtin': {
+      'color': colors.teal.dark,
+  },
+  'inserted': {
+      'color': colors.teal.dark,
+  },
+  'entity': {
+      'color': colors.blue.dark,
+      'cursor': 'help',
+  },
+  'url': {
+      'color': colors.blue.dark,
+  },
+  '.language-css .token.string': {
+      'color': colors.blue.dark,
+  },
+  '.style .token.string': {
+      'color': colors.blue.dark,
+  },
+  'variable': {
+      'color': colors.blue.dark,
+  },
+  'atrule': {
+      'color': colors.orange.dark,
+  },
+  'attr-value': {
+      'color': colors.orange.dark,
+  },
+  'regex': {
+      'color': colors.orange.dark,
+  },
+  'important': {
+      'color': colors.orange.dark,
+      'fontWeight': 'bold',
+  },
+  'bold': {
+      'fontWeight': 'bold',
+  },
+  'italic': {
+      'fontStyle': 'italic',
+  },
+};


### PR DESCRIPTION
#### What does this PR do?
Adds the code block dark and light themes

#### What testing has been done on this PR?

#### Any background context you want to provide?
Related to https://github.com/grommet/hpe-design-system/pull/1903

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible

#### How should this PR be communicated in the release notes?
