### PR TITLE
Fix margin in prism theme

### DIFF
--- a/src/js/themes/prism.js
+++ b/src/js/themes/prism.js
@@ -91,7 +91,7 @@ const themeMode = (mode) => ({
     msHyphens: 'none',
     hyphens: 'none',
     padding: '1em',
-    margin: '0.5em 0',
+    margin: '0',
     overflow: 'auto',
     borderRadius: '0.3em',
   },


### PR DESCRIPTION
#### What does this PR do?
Removes extra margin around the code block

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/1958

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible (there shouldn't have been a margin)

#### How should this PR be communicated in the release notes?
