### PR TITLE
Update colors for code block comments

### DIFF
--- a/src/js/themes/prism.js
+++ b/src/js/themes/prism.js
@@ -23,7 +23,7 @@ const colors = {
   },
   char: { dark: hpeColors['teal!'], light: hpeColors.teal.dark },
   code: hpeColors.text,
-  comment: hpeColors['status-unknown'],
+  comment: { dark: hpeColors.green.light, light: hpeColors.green.dark },
   entity: { dark: hpeColors.blue.light, light: hpeColors.blue.dark },
   function: {
     dark: hpeColors['status-critical'].light,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Updates the colors for the code block comments in dark mode and light mode to meet WCAG AA accessibility guidelines

#### What testing has been done on this PR?
Browser

#### Any background context you want to provide?
Reviewed colors with Aditi and Vicky and they've been approved

#### What are the relevant issues?
https://github.com/grommet/grommet-theme-hpe/issues/217

#### Screenshots (if appropriate)
![prism_comment_dark](https://user-images.githubusercontent.com/2924479/138939616-c077f9bc-fe36-4e6a-b7b8-8b00cd963781.jpg)
![prism_comment_light](https://user-images.githubusercontent.com/2924479/138939618-4576ded7-b044-4ab7-ba47-75642c844ac7.jpg)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backward compatible

#### How should this PR be communicated in the release notes?
Slack
