### PR TITLE
align label to be start

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -14,12 +14,12 @@ import { Unsorted } from 'grommet-icons/icons/Unsorted';
 
 import { colors } from './colors';
 
-const isObject = item =>
+const isObject = (item) =>
   item && typeof item === 'object' && !Array.isArray(item);
 
-const deepFreeze = obj => {
+const deepFreeze = (obj) => {
   Object.keys(obj).forEach(
-    key => key && isObject(obj[key]) && Object.freeze(obj[key]),
+    (key) => key && isObject(obj[key]) && Object.freeze(obj[key]),
   );
   return Object.freeze(obj);
 };
@@ -396,21 +396,25 @@ export const hpe = deepFreeze({
         `,
       },
       extend: ({ checked, theme }) => `
-        ${checked &&
+        ${
+          checked &&
           `background-color: ${
             theme.global.colors.green[theme.dark ? 'dark' : 'light']
-          };`}
+          };`
+        }
       `,
     },
     extend: ({ disabled, theme }) => `
-      ${!disabled &&
+      ${
+        !disabled &&
         `:hover {
         background-color: ${
           theme.global.colors['background-contrast'][
             theme.dark ? 'dark' : 'light'
           ]
         };
-      }`}
+      }`
+      }
       font-weight: 500;
       width: auto;
       padding: ${theme.global.edgeSize.xsmall} ${theme.global.edgeSize.small};
@@ -437,7 +441,8 @@ export const hpe = deepFreeze({
       color: 'text-strong',
       extend: ({ column, sort, sortable, theme }) =>
         `
-          ${sort &&
+          ${
+            sort &&
             sort.property === column &&
             `
             background: ${
@@ -445,8 +450,10 @@ export const hpe = deepFreeze({
                 theme.dark ? 'dark' : 'light'
               ]
             }
-          `};
-          ${sortable &&
+          `
+          };
+          ${
+            sortable &&
             sort &&
             sort.property !== column &&
             `
@@ -458,7 +465,8 @@ export const hpe = deepFreeze({
                   opacity: 1;
                 }
               }
-            `};
+            `
+          };
         `,
       font: {
         weight: 'bold',
@@ -915,7 +923,7 @@ export const hpe = deepFreeze({
     control: {
       extend: ({ disabled }) => css`
         ${disabled &&
-          `
+        `
         opacity: 0.3;
         input {
           cursor: default;

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -379,6 +379,9 @@ export const hpe = deepFreeze({
       }`,
     },
     gap: 'small',
+    label: {
+      align: 'start',
+    },
     toggle: {
       background: 'background',
       color: 'background',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR aligns label for `checkbox` so when there is multi-lines it is aligned start
#### What testing has been done on this PR?
tested with aries.theme in design-system
#### Any background context you want to provide?
currently we have:
<img width="596" alt="Screen Shot 2021-11-09 at 12 44 44 PM" src="https://user-images.githubusercontent.com/42451602/140993826-dce4e0ac-a7c2-4857-97f9-e7972d65f6e2.png">


what we want:
<img width="362" alt="Screen Shot 2021-11-09 at 12 45 12 PM" src="https://user-images.githubusercontent.com/42451602/140993877-7576829d-083a-4b6e-b084-da8d784a7894.png">


#### What are the relevant issues?
closes https://github.com/grommet/hpe-design-system/issues/2000
#### Screenshots (if appropriate)
look above
#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
no
#### How should this PR be communicated in the release notes?
yes