### PR TITLE
align button gap with figma to be xsmall

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -165,6 +165,7 @@ export const hpe = deepFreeze({
         weight: 700,
       },
     },
+    gap: 'xsmall',
     primary: {
       background: {
         color: 'green',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR changes the gap between the icon and label to be `xsmall`
#### What testing has been done on this PR?
design system testing
#### Any background context you want to provide?
per [Figma](https://www.figma.com/file/Oi5UEEQ33VCAyOKQcZ8Nr8/HPE-Button-Component?node-id=0%3A1) the `gap` should be `xsmall`
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
