### PR TITLE
change the places we have text-weak to text-xweak

### DIFF
--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -41,7 +41,7 @@ export const colors = {
     light: '#757575',
   },
   'text-xweak': {
-    dark: '#606b7d',
+    dark: '#606B7D',
     light: '#bbbbbb',
   },
   border: {

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -37,10 +37,13 @@ export const colors = {
     light: '#000000',
   },
   'text-weak': {
-    dark: '#606B7D',
-    light: '#BBBBBB',
+    dark: '#8c98aa',
+    light: '#757575',
   },
-  'text-xweak': 'text-weak',
+  'text-xweak': {
+    dark: '#606b7d',
+    light: '#bbbbbb',
+  },
   border: {
     dark: '#7887A1',
     light: '#999999',

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -37,7 +37,7 @@ export const colors = {
     light: '#000000',
   },
   'text-weak': {
-    dark: '#8c98aa',
+    dark: '#8C98AA',
     light: '#757575',
   },
   'text-xweak': {

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -42,7 +42,7 @@ export const colors = {
   },
   'text-xweak': {
     dark: '#606B7D',
-    light: '#bbbbbb',
+    light: '#BBBBBB',
   },
   border: {
     dark: '#7887A1',

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -230,7 +230,7 @@ export const hpe = deepFreeze({
       background: {
         color: 'transparent',
       },
-      color: 'text-weak',
+      color: 'text-xweak',
       primary: {
         border: {
           color: 'border-weak',
@@ -563,7 +563,7 @@ export const hpe = deepFreeze({
       remove: FormTrash,
     },
     message: {
-      color: 'text-weak',
+      color: 'text-xweak',
     },
     pad: { horizontal: 'xsmall' },
     extend: 'border-radius: 4px;',
@@ -588,7 +588,7 @@ export const hpe = deepFreeze({
         color: 'border-weak',
       },
       label: {
-        color: 'text-weak',
+        color: 'text-xweak',
       },
     },
     error: {
@@ -843,7 +843,7 @@ export const hpe = deepFreeze({
         },
       },
       disabled: {
-        color: 'text-weak',
+        color: 'text-xweak',
       },
     },
   },
@@ -987,7 +987,7 @@ export const hpe = deepFreeze({
       },
     },
     disabled: {
-      color: 'text-weak',
+      color: 'text-xweak',
     },
     pad: {
       // top and bottom pad need to be defined individually, specifying


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR goes through and changes the current values we have for `text-weak` to `text-xweak`
#### What testing has been done on this PR?
tested this in the design system 
#### Any background context you want to provide?
 anything that was `text-weak` should be `text-xweak`
#### What are the relevant issues?
closes https://github.com/grommet/hpe-design-system/issues/2312
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
