### PR TITLE
Change Select options font weight

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -201,7 +201,7 @@ export const hpe = deepFreeze({
         radius: '0px',
       },
       font: {
-        weight: 400,
+        weight: 500,
       },
     },
     active: {
@@ -950,11 +950,7 @@ export const hpe = deepFreeze({
       down: FormDown,
       up: FormUp,
     },
-    options: {
-      text: {
-        weight: 500,
-      },
-    },
+    options: undefined,
   },
   spinner: {
     container: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -950,7 +950,11 @@ export const hpe = deepFreeze({
       down: FormDown,
       up: FormUp,
     },
-    options: undefined,
+    options: {
+      text: {
+        weight: 500,
+      },
+    },
   },
   spinner: {
     container: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR changes the `text` in the select options to have a weight of 500
#### What testing has been done on this PR?
site
#### Any background context you want to provide?
match what is on figma 
#### What are the relevant issues?
closes https://github.com/grommet/hpe-design-system/issues/1242
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
