### PR TITLE
Added correct page width for hpe to the theme

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -833,6 +833,26 @@ export const hpe = deepFreeze({
       color: 'text-strong',
     },
   },
+  page: {
+    wide: {
+      width: {
+        min: '336px', // 336 + 24 (margin) + 24 (margin) = 384 (e.g. 'medium')
+        max: 'xxlarge',
+      },
+    },
+    narrow: {
+      width: {
+        min: '336px', // 336 + 24 (margin) + 24 (margin) = 384 (e.g. 'medium')
+        max: 'large',
+      },
+    },
+    full: {
+      width: {
+        min: '336px', // 336 + 24 (margin) + 24 (margin) = 384 (e.g. 'medium')
+        max: '100%',
+      },
+    }
+  },
   pagination: {
     button: {
       font: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Added the correct min page width to the theme. The grommet base theme uses t-shirt sizing for the min width but the hpe theme uses 336px for its min width.

Note: once the hpe theme has xsmall and xlarge breakpoints the page theme will need to be updated to include these.

#### What testing has been done on this PR?
Theme was tested in https://github.com/grommet/hpe-design-system/pull/2439 and https://github.com/grommet/hpe-design-system/pull/2433

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/2426

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backwards compatible (page hasn't been released on grommet yet)

#### How should this PR be communicated in the release notes?
