### PR TITLE
Upgrade to React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "peerDependencies": {
     "grommet": "^2.17.2",
     "grommet-icons": "^4.5.0",
-    "react": "^16.13.1 || ^17.0.1",
+    "react": "^16.13.1 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.0.0"
   },
   "devDependencies": {
@@ -48,7 +48,7 @@
     "pre-commit": "^1.2.2",
     "prettier": "^2.3.2",
     "pretty-quick": "^3.1.1",
-    "react": "^17.0.2",
+    "react": "^18.0.0",
     "simple-git": "^2.44.0",
     "styled-components": "^5.0.0",
     "webpack": "^5.51.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3391,13 +3391,12 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0.tgz#b468736d1f4a5891f38585ba8e8fb29f91c3cb96"
+  integrity sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 readable-stream@^2.2.2:
   version "2.3.7"


### PR DESCRIPTION
#### What does this PR do?
Upgrade to use react v18.0.0

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/2538

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backwards compatible
#### How should this PR be communicated in the release notes?
Added support for React 18