### PR TITLE
Add page header theming

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -981,6 +981,34 @@ export const hpe = deepFreeze({
       },
     },
   },
+  pageHeader: {
+    title: {
+      size: 'small',
+    },
+    subtitle: {
+      size: 'large',
+    },
+    xsmall: {
+      areas: [
+        ['parent', 'null'],
+        ['title', 'actions'],
+        ['subtitle', 'actions'],
+      ],
+      columns: [['small', 'flex'], 'auto'],
+      rows: ['auto', 'auto', 'auto'],
+      gap: { row: 'xsmall', column: 'large' },
+    },
+    xlarge: {
+      areas: [
+        ['parent', 'null'],
+        ['title', 'actions'],
+        ['subtitle', 'actions'],
+      ],
+      columns: [['medium', 'large'], 'auto'],
+      rows: ['auto', 'auto', 'auto'],
+      gap: { row: 'xsmall', column: 'large' },
+    },
+  },
   pagination: {
     button: {
       font: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -985,10 +985,6 @@ export const hpe = deepFreeze({
     actions: {
       pad: { vertical: 'xxsmall' }, // aligns button height with heading font-size instead of line-height
     },
-    pad: {
-      top: 'large',
-      bottom: 'medium',
-    },
     subtitle: {
       size: 'large',
     },

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -982,25 +982,32 @@ export const hpe = deepFreeze({
     },
   },
   pageHeader: {
-    title: {
-      size: 'small',
+    actions: {
+      pad: { vertical: 'xxsmall' }, // aligns button height with heading font-size instead of line-height
+    },
+    pad: {
+      top: 'large',
+      bottom: 'medium',
     },
     subtitle: {
       size: 'large',
     },
+    title: {
+      size: 'small',
+    },
     xsmall: {
       areas: [
-        ['parent', 'null'],
+        ['parent', 'parent'],
         ['title', 'actions'],
         ['subtitle', 'actions'],
       ],
       columns: [['small', 'flex'], 'auto'],
       rows: ['auto', 'auto', 'auto'],
-      gap: { row: 'xsmall', column: 'large' },
+      gap: { row: 'xsmall', column: 'medium' },
     },
     xlarge: {
       areas: [
-        ['parent', 'null'],
+        ['parent', 'parent'],
         ['title', 'actions'],
         ['subtitle', 'actions'],
       ],


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds theming for Page Header elements

#### What testing has been done on this PR?

Implemented on DS site PR: https://github.com/grommet/hpe-design-system/pull/2574

#### Any background context you want to provide?

#### What are the relevant issues?

Related to [#2562](https://github.com/grommet/hpe-design-system/issues/2562)
Related to [#2603](https://github.com/grommet/hpe-design-system/issues/2603)
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible.

#### How should this PR be communicated in the release notes?
Added NEW PageHeader styling.