### PR TITLE
First cut at Button changes for the HPE Brand refresh

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -15,12 +15,12 @@ import { colors } from './colors';
 
 const baseSpacing = 24;
 
-const isObject = (item) =>
+const isObject = item =>
   item && typeof item === 'object' && !Array.isArray(item);
 
-const deepFreeze = (obj) => {
+const deepFreeze = obj => {
   Object.keys(obj).forEach(
-    (key) => key && isObject(obj[key]) && Object.freeze(obj[key]),
+    key => key && isObject(obj[key]) && Object.freeze(obj[key]),
   );
   return Object.freeze(obj);
 };
@@ -202,6 +202,16 @@ export const hpe = deepFreeze({
     },
   },
   button: {
+    cta: {
+      background: {
+        color: 'brand',
+      },
+      border: undefined,
+      color: 'white', // 'text-strong',
+      font: {
+        weight: 700,
+      },
+    },
     default: {
       color: 'text-strong',
       border: undefined,
@@ -290,6 +300,21 @@ export const hpe = deepFreeze({
       opacity: 1.0,
     },
     hover: {
+      cta: {
+        extend: ({ active, colorValue, theme }) => {
+          let color;
+          if (!colorValue && !active) {
+            if (theme.dark) {
+              color = 'rgba(0, 0, 0, 0.2)';
+            } else color = 'rgba(0, 0, 0, 0.2)'; // TBD
+          }
+
+          const style = `inset 0 0 100px 100px ${color}`;
+          return `-moz-box-shadow: ${style};
+            -webkit-box-shadow: ${style};
+            box-shadow: ${style};`;
+        },
+      },
       default: {
         background: {
           color: 'background-contrast',
@@ -326,38 +351,6 @@ export const hpe = deepFreeze({
             box-shadow: ${style};`;
         },
       },
-    },
-    size: {
-      small: {
-        border: {
-          radius: '4px',
-        },
-        pad: {
-          vertical: '4px',
-          horizontal: '8px',
-        },
-      },
-      medium: {
-        border: {
-          radius: '4px',
-        },
-        pad: {
-          vertical: '6px',
-          horizontal: '12px',
-        },
-      },
-      large: {
-        border: {
-          radius: '6px',
-        },
-        pad: {
-          vertical: '6px',
-          horizontal: '16px',
-        },
-      },
-    },
-    border: {
-      radius: '4px',
     },
     color: 'text-strong',
     padding: {
@@ -456,25 +449,21 @@ export const hpe = deepFreeze({
         `,
       },
       extend: ({ checked, theme }) => `
-        ${
-          checked &&
+        ${checked &&
           `background-color: ${
             theme.global.colors.green[theme.dark ? 'dark' : 'light']
-          };`
-        }
+          };`}
       `,
     },
     extend: ({ disabled, theme }) => `
-      ${
-        !disabled &&
+      ${!disabled &&
         `:hover {
         background-color: ${
           theme.global.colors['background-contrast'][
             theme.dark ? 'dark' : 'light'
           ]
         };
-      }`
-      }
+      }`}
       font-weight: 500;
       width: auto;
       padding: ${theme.global.edgeSize.xsmall} ${theme.global.edgeSize.small};
@@ -501,8 +490,7 @@ export const hpe = deepFreeze({
       color: 'text-strong',
       extend: ({ column, sort, sortable, theme }) =>
         `
-          ${
-            sort &&
+          ${sort &&
             sort.property === column &&
             `
             background: ${
@@ -510,10 +498,8 @@ export const hpe = deepFreeze({
                 theme.dark ? 'dark' : 'light'
               ]
             }
-          `
-          };
-          ${
-            sortable &&
+          `};
+          ${sortable &&
             sort &&
             sort.property !== column &&
             `
@@ -525,8 +511,7 @@ export const hpe = deepFreeze({
                   opacity: 1;
                 }
               }
-            `
-          };
+            `};
         `,
       font: {
         weight: 'bold',
@@ -1123,7 +1108,7 @@ export const hpe = deepFreeze({
     control: {
       extend: ({ disabled }) => css`
         ${disabled &&
-        `
+          `
         opacity: 0.3;
         input {
           cursor: default;

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -25,6 +25,11 @@ const deepFreeze = obj => {
   return Object.freeze(obj);
 };
 
+const hpeElement = color =>
+  `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 24' preserveAspectRatio='none'%3E%3Cg x='0' y='0' fill='${encodeURIComponent(
+    color,
+  )}' fill-rule='evenodd' clip-rule='evenodd' %3E%3Cpath d='M2 6h44v12H2V6zm3 3h38v6H5V9z' /%3E%3C/g%3E%3C/svg%3E")`;
+
 export const hpe = deepFreeze({
   defaultMode: 'light',
   global: {
@@ -211,7 +216,24 @@ export const hpe = deepFreeze({
       font: {
         weight: 700,
       },
+      extend: props => {
+        const color = props.disabled ? 'text-xweak' : 'text-strong';
+        const dark = props.active || props.disabled ? props.theme.dark : true;
+        const colorValue =
+          props.theme.global.colors[color][dark ? 'dark' : 'light'];
+
+        return `&:after {
+          display: inline-block;
+          width: 48px;
+          height: 24px;
+          padding-left: 12px;
+          padding-bottom: 3px;
+          vertical-align: middle;
+          content: ${hpeElement(colorValue)};
+        }`;
+      },
     },
+
     default: {
       color: 'text-strong',
       border: undefined,
@@ -286,6 +308,12 @@ export const hpe = deepFreeze({
         color: 'transparent',
       },
       color: 'text-xweak',
+      cta: {
+        border: {
+          color: 'border-weak',
+          width: '2px',
+        },
+      },
       primary: {
         border: {
           color: 'border-weak',

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -226,7 +226,7 @@ export const hpe = deepFreeze({
           display: inline-block;
           width: 48px;
           height: 24px;
-          padding-left: 12px;
+          padding-left: ${props.hasLabel ? '12px' : '0px'};
           padding-bottom: 3px;
           vertical-align: middle;
           content: ${hpeElement(colorValue)};

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -216,6 +216,8 @@ export const hpe = deepFreeze({
       font: {
         weight: 700,
       },
+     // TODO: Enhance Grommet to allow theme to set `button.{kind}.icon` which is an SVG.
+     // With this enhancement, the `extend` property definition should be able to be removed.
       extend: props => {
         const color = props.disabled ? 'text-xweak' : 'text-strong';
         const dark = props.active || props.disabled ? props.theme.dark : true;


### PR DESCRIPTION
A first cut changes to the theme to add a CTA kind for Button and round the buttons.

#### What does this PR do?
- Removes the HPE specific Button border radius settings and lets the base rounded buttons be the style.
- Adds  a `cta` kind for the Call To Action button style with the brand coloring and a hover style similar to the primary button. Note that primary buttons and secondary button borders are a brighter green than the brand color.

What this doesn't address:
- Embedding the HPE element icon within the styling
- Some form of animation of the element on hover


#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/hpe-design-system/issues/2779
https://github.com/grommet/hpe-design-system/issues/2774

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12054362/182483569-bbe2b24d-e7f0-4e7a-890c-c0ff8fd3b70b.png)

![image](https://user-images.githubusercontent.com/12054362/182483005-2ed06655-8473-4714-aa0e-0836b6cf56e2.png)
![image](https://user-images.githubusercontent.com/12054362/182483151-e830b2d4-6ce0-4c0c-b5de-e93cbb818fcc.png)
![image](https://user-images.githubusercontent.com/12054362/182483260-1e9f2518-cb9b-4246-8af0-571546eefc23.png)
![image](https://user-images.githubusercontent.com/12054362/182483301-4ec161c8-96ca-4360-b1b4-3d5f6abe8dc7.png)

![image](https://user-images.githubusercontent.com/12054362/182483444-33ff4801-c5b3-487a-8722-c0bbbad8e09a.png)

![image](https://user-images.githubusercontent.com/12054362/182483881-d8896625-8a60-4fe9-9365-52c12081c808.png)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Not really a breaking change but it is a significant visual difference to existing buttons including drops' hovers and such.


#### How should this PR be communicated in the release notes?
