### PR TITLE
update checkBox.pad to use values from extend

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -444,6 +444,7 @@ export const hpe = deepFreeze({
     },
     pad: {
       vertical: 'xsmall',
+      horizontal: 'small',
     },
     toggle: {
       background: 'background',
@@ -614,12 +615,6 @@ export const hpe = deepFreeze({
     extend: 'border-radius: 4px;',
   },
   formField: {
-    checkBox: {
-      pad: {
-        horizontal: 'small',
-        vertical: 'xsmall',
-      },
-    },
     content: {
       margin: { vertical: 'xsmall' },
       pad: undefined,

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -412,8 +412,9 @@ export const hpe = deepFreeze({
       border: {
         color: undefined,
       },
+      // use extend to leverage focusIndicator for background on hover
       background: {
-        color: 'background-contrast',
+        color: undefined,
       },
     },
     color: 'background',
@@ -464,9 +465,16 @@ export const hpe = deepFreeze({
         }
       `,
     },
-    extend: ({ disabled, theme }) => `
+    // focusIndicator is "false" when CheckBox is in a FormField.
+    // So, only apply hover background & horizontal pad when in FormField.
+
+    // NOTE: This won't work if teams have wrapped the Grommet input
+    // and named it "EZCheckBox" (for example), since FormField specifically
+    // looks for "CheckBox".
+    extend: ({ disabled, focusIndicator, theme }) => `
       ${
         !disabled &&
+        !focusIndicator &&
         `:hover {
         background-color: ${
           theme.global.colors['background-contrast'][
@@ -477,7 +485,9 @@ export const hpe = deepFreeze({
       }
       font-weight: 500;
       width: auto;
-      padding: ${theme.global.edgeSize.xsmall} ${theme.global.edgeSize.small};
+      padding: ${theme.global.edgeSize.xsmall} ${
+      !focusIndicator ? theme.global.edgeSize.small : 0
+    };
     `,
   },
   checkBoxGroup: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -442,6 +442,9 @@ export const hpe = deepFreeze({
     label: {
       align: 'start',
     },
+    pad: {
+      vertical: 'xsmall',
+    },
     toggle: {
       background: 'background',
       color: 'background',
@@ -464,29 +467,26 @@ export const hpe = deepFreeze({
         }
       `,
     },
-    // focusIndicator is "false" when CheckBox is in a FormField.
-    // So, only apply hover background & horizontal pad when in FormField.
-
-    // NOTE: This won't work if teams have wrapped the Grommet input
-    // and named it "EZCheckBox" (for example), since FormField specifically
-    // looks for "CheckBox".
-    extend: ({ disabled, focusIndicator, theme }) => `
-      ${
-        !disabled &&
-        `:hover {
-        background-color: ${
-          theme.global.colors['background-contrast'][
-            theme.dark ? 'dark' : 'light'
-          ]
-        };
-      }`
-      }
-      font-weight: 500;
-      width: auto;
-      padding: ${theme.global.edgeSize.xsmall} ${
-      !focusIndicator ? theme.global.edgeSize.small : 0
+    extend: ({ disabled, plainProp, theme }) => `
+    ${
+      !disabled &&
+      `:hover {
+      background-color: ${
+        theme.global.colors['background-contrast'][
+          theme.dark ? 'dark' : 'light'
+        ]
+      };
+    }`
+    }
+    ${
+      !plainProp &&
+      `padding-left: ${theme.global.edgeSize.small};
+       padding-right: ${theme.global.edgeSize.small};`
     };
-    `,
+    font-weight: 500;
+    width: auto;
+  };
+  `,
   },
   checkBoxGroup: {
     container: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -412,7 +412,6 @@ export const hpe = deepFreeze({
       border: {
         color: undefined,
       },
-      // use extend to leverage focusIndicator for background on hover
       background: {
         color: 'background-contrast',
       },

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -414,7 +414,7 @@ export const hpe = deepFreeze({
       },
       // use extend to leverage focusIndicator for background on hover
       background: {
-        color: undefined,
+        color: 'background-contrast',
       },
     },
     color: 'background',
@@ -474,7 +474,6 @@ export const hpe = deepFreeze({
     extend: ({ disabled, focusIndicator, theme }) => `
       ${
         !disabled &&
-        !focusIndicator &&
         `:hover {
         background-color: ${
           theme.global.colors['background-contrast'][

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -442,6 +442,9 @@ export const hpe = deepFreeze({
     label: {
       align: 'start',
     },
+    pad: {
+      vertical: 'xsmall',
+    },
     toggle: {
       background: 'background',
       color: 'background',

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -442,9 +442,6 @@ export const hpe = deepFreeze({
     label: {
       align: 'start',
     },
-    pad: {
-      vertical: 'xsmall',
-    },
     toggle: {
       background: 'background',
       color: 'background',

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -467,7 +467,7 @@ export const hpe = deepFreeze({
         }
       `,
     },
-    extend: ({ disabled, plainProp, theme }) => `
+    extend: ({ disabled, theme }) => `
     ${
       !disabled &&
       `:hover {
@@ -478,11 +478,6 @@ export const hpe = deepFreeze({
       };
     }`
     }
-    ${
-      !plainProp &&
-      `padding-left: ${theme.global.edgeSize.small};
-       padding-right: ${theme.global.edgeSize.small};`
-    };
     font-weight: 500;
     width: auto;
   };
@@ -619,6 +614,12 @@ export const hpe = deepFreeze({
     extend: 'border-radius: 4px;',
   },
   formField: {
+    checkBox: {
+      pad: {
+        horizontal: 'small',
+        vertical: 'xsmall',
+      },
+    },
     content: {
       margin: { vertical: 'xsmall' },
       pad: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR uses the `checkBox.pad` to set values instead of the `extend`
#### What testing has been done on this PR?
design system site

```

checkBox: {
   pad: {
          vertical: 'xsmall',
          horizontal: 'small',
  }
    extend: ({ disabled, theme }) => `
    ${
      !disabled &&
      `:hover {
      background-color: ${
        theme.global.colors['background-contrast'][
          theme.dark ? 'dark' : 'light'
        ]
      };
    }`
    }
    font-weight: 500;
    width: auto;
    };
  `,
  },

```
paste into aries theme to test 
#### Any background context you want to provide?
users will need to use `pad` prop to overrid the theme Padding
#### What are the relevant issues?
closes https://github.com/grommet/hpe-design-system/issues/2810
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
 backward compatible

#### How should this PR be communicated in the release notes?
pad fixed for checkbox outside formfield