### PR TITLE
Add HPE icon to CTA buttons and update kind-specific padding

### DIFF
--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -133,4 +133,6 @@ export const colors = {
   'graph-4': 'teal!',
   focus: 'teal!',
   placeholder: 'text-weak',
+  'text-primary-button': '#FFFFFF',
+  'background-cta-alternate': '#F2F2F2',
 };

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -10,6 +10,7 @@ import { FormNext } from 'grommet-icons/icons/FormNext';
 import { FormPrevious } from 'grommet-icons/icons/FormPrevious';
 import { FormUp } from 'grommet-icons/icons/FormUp';
 import { Unsorted } from 'grommet-icons/icons/Unsorted';
+import { Hpe } from 'grommet-icons/icons/Hpe';
 
 import { backgrounds } from './backgrounds';
 import { colors } from './colors';
@@ -25,11 +26,6 @@ const deepFreeze = (obj) => {
   );
   return Object.freeze(obj);
 };
-
-const hpeElement = (color) =>
-  `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 24' preserveAspectRatio='none'%3E%3Cg x='0' y='0' fill='${encodeURIComponent(
-    color,
-  )}' fill-rule='evenodd' clip-rule='evenodd' %3E%3Cpath d='M2 6h44v12H2V6zm3 3h38v6H5V9z' /%3E%3C/g%3E%3C/svg%3E")`;
 
 export const hpe = deepFreeze({
   // Option A - Rounded buttons only
@@ -211,57 +207,26 @@ export const hpe = deepFreeze({
   },
   button: {
     'cta-primary': {
-      background: {
-        color: 'brand',
+      background: { color: 'brand' },
+      border: {
+        radius: '100px',
       },
-      border: undefined,
-      color: 'white', // 'text-strong',
-      font: {
-        weight: 700,
-      },
-      // TODO: Enhance Grommet to allow theme to set `button.{kind}.icon` which is an SVG.
-      // With this enhancement, the `extend` property definition should be able to be removed.
-      extend: (props) => {
-        const color = props.disabled ? 'text-xweak' : 'text-strong';
-        const dark = props.active || props.disabled ? props.theme.dark : true;
-        const colorValue =
-          props.theme.global.colors[color][dark ? 'dark' : 'light'];
-
-        return `&:after {
-            display: inline-block;
-            width: 48px;
-            height: 20px;
-            padding-left: ${props.hasLabel ? '12px' : '0px'};
-            vertical-align: text-bottom;
-            content: ${hpeElement(colorValue)};
-          }`;
-      },
+      color: 'white', // text-strong
+      font: { weight: 'bold' },
+      icon: <Hpe />,
+      reverse: true,
     },
     'cta-alternate': {
-      background: {
-        color: 'background-contrast',
+      background: 'background-contrast',
+      border: {
+        radius: '100px',
       },
-      border: undefined,
       color: 'text-strong',
       font: {
-        weight: 700,
+        weight: 'bold',
       },
-      extend: (props) => {
-        const color = props.disabled ? 'text-xweak' : 'green!';
-        const dark = props.active || props.disabled ? props.theme.dark : true;
-        const colorValue = !props.disabled
-          ? props.theme.global.colors[color]
-          : props.theme.global.colors[color][dark ? 'dark' : 'light'];
-
-        return `&:after {
-            display: inline-block;
-            width: 48px;
-            height: 20px;
-            padding-left: ${props.hasLabel ? '12px' : '0px'};
-            vertical-align: text-bottom;
-            content: ${hpeElement(colorValue)};
-          }`;
-      },
+      icon: <Hpe color="brand" />,
+      reverse: true,
     },
     default: {
       color: 'text-strong',
@@ -273,17 +238,17 @@ export const hpe = deepFreeze({
     gap: 'xsmall',
     primary: {
       background: {
-        color: 'green',
+        color: 'brand',
       },
       border: undefined,
-      color: 'text-strong',
+      color: 'white', // text-strong
       font: {
         weight: 700,
       },
     },
     secondary: {
       border: {
-        color: 'green',
+        color: 'brand',
         width: '2px',
       },
       color: 'text-strong',
@@ -437,23 +402,108 @@ export const hpe = deepFreeze({
     },
     size: {
       small: {
+        border: {
+          radius: '4px',
+        },
         pad: {
           vertical: '4px',
-          horizontal: '24px',
+          horizontal: '8px',
+        },
+        'cta-primary': {
+          pad: {
+            vertical: '3px',
+            horizontal: '12px',
+          },
+        },
+        'cta-alternate': {
+          pad: {
+            vertical: '3px',
+            horizontal: '12px',
+          },
         },
       },
       medium: {
+        border: {
+          radius: '4px',
+        },
         pad: {
           vertical: '6px',
-          horizontal: '24px',
+          horizontal: '12px',
+        },
+        'cta-primary': {
+          pad: {
+            vertical: '6px',
+            horizontal: '16px',
+          },
+        },
+        'cta-alternate': {
+          pad: {
+            vertical: '6px',
+            horizontal: '16px',
+          },
         },
       },
       large: {
+        border: {
+          radius: '6px',
+        },
         pad: {
-          vertical: '6px',
-          horizontal: '24px',
+          vertical: '8px',
+          horizontal: '16px',
+        },
+        'cta-primary': {
+          pad: {
+            vertical: '8px',
+            horizontal: '20px',
+          },
+        },
+        'cta-alternate': {
+          pad: {
+            vertical: '8px',
+            horizontal: '20px',
+          },
         },
       },
+      xlarge: {
+        border: {
+          radius: '6px',
+        },
+        pad: {
+          vertical: '10px',
+          horizontal: '20px',
+        },
+        'cta-primary': {
+          pad: {
+            vertical: '10px',
+            horizontal: '28px',
+          },
+        },
+        'cta-alternate': {
+          pad: {
+            vertical: '10px',
+            horizontal: '28px',
+          },
+        },
+      },
+    },
+    // aligning with brand central which follows slightly different interval between t-shirt sizes
+    extend: ({ sizeProp }) => {
+      let fontSize = '19px'; // necessary so cta-primary label is accessible on HPE green background
+      let lineHeight = '24px';
+      if (sizeProp === 'small') {
+        fontSize = '16px';
+        lineHeight = '22px';
+      } else if (sizeProp === 'large') {
+        fontSize = '20px';
+        lineHeight = '26px';
+      } else if (sizeProp === 'xlarge') {
+        fontSize = '22px';
+        lineHeight = '28px';
+      }
+      return `
+      font-size: ${fontSize};
+      line-height: ${lineHeight}
+      `;
     },
   },
   calendar: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -211,13 +211,13 @@ export const hpe = deepFreeze({
       border: {
         radius: '100px',
       },
-      color: 'white', // text-strong
+      color: 'text-primary-button',
       font: { weight: 'bold' },
       icon: <Hpe />,
       reverse: true,
     },
     'cta-alternate': {
-      background: 'background-contrast',
+      background: 'background-cta-alternate',
       border: {
         radius: '100px',
       },
@@ -241,7 +241,7 @@ export const hpe = deepFreeze({
         color: 'brand',
       },
       border: undefined,
-      color: 'white', // text-strong
+      color: 'text-primary-button',
       font: {
         weight: 700,
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds HPE element to cta-primary and cta-alternate buttons. Leverages new grommet capabilities re: kind-specific padding to adjust padding for the CTA buttons at various sizes.

Updates secondary and primary buttons to use `brand` green.

Updates label font size/line height of buttons to align with brand.

#### What testing has been done on this PR?
Local in aries site -- see screenshots below.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #271 

#### Screenshots (if appropriate)
<img width="1403" alt="Screen Shot 2022-08-26 at 12 57 55 PM" src="https://user-images.githubusercontent.com/12522275/186982121-1374215c-46d2-4cd0-9b8b-aa315d0eb479.png">


medium, 36px
<img width="322" alt="Screen Shot 2022-08-26 at 12 00 59 PM" src="https://user-images.githubusercontent.com/12522275/186976675-21fcab4a-18c3-439a-820c-642dd72a34ac.png">

large, 42px
<img width="317" alt="Screen Shot 2022-08-26 at 12 00 54 PM" src="https://user-images.githubusercontent.com/12522275/186976704-656ebb0c-a01b-4715-a23c-9aebd166043e.png">

xlarge, 48px
<img width="315" alt="Screen Shot 2022-08-26 at 12 00 48 PM" src="https://user-images.githubusercontent.com/12522275/186976727-403a81d3-24c6-4196-b824-ac4516e85212.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
