### PR TITLE
update tab active state

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1162,9 +1162,9 @@ export const hpe = deepFreeze({
     border: {
       side: 'bottom',
       color: 'transparent',
-      size: 'medium',
+      size: '6px',
       active: {
-        color: 'border-strong',
+        color: 'text-strong',
       },
       disabled: {
         color: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
updates active state in Tab 
#### What testing has been done on this PR?
Based on user research we have decided to modify the active state tab to increase user recognition time.
DS site
#### Any background context you want to provide?
Based on user research we have decided to modify the active state tab to increase user recognition time. The new active state can be found here: https://www.figma.com/file/Kp4dWyhUTnKIJ1Cg5CoL9o/HPE-Tabs-Component?node-id=4317%3A40074

The `6px` is not a t-shirt size for border however we go from 4px to 12px so not sure where we can meet in the middle
#### What are the relevant issues?
closes https://github.com/grommet/grommet/issues/6292
#### Screenshots (if appropriate)
<img width="675" alt="Screen Shot 2022-08-29 at 11 33 15 AM" src="https://user-images.githubusercontent.com/42451602/187262761-6242cfcb-5ab3-49db-b05f-696a3a2fa045.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
it would change the active look
#### How should this PR be communicated in the release notes?
release notes