### PR TITLE
add new hover treatment

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -415,6 +415,16 @@ export const hpe = deepFreeze({
       background: {
         color: 'background-contrast',
       },
+      extend: ({ disabled, pad, theme }) => `
+      ${
+        !disabled &&
+        pad &&
+        typeof pad !== 'object' &&
+        `outline: solid ${
+          theme.global.colors['border-strong'][theme.dark ? 'dark' : 'light']
+        };`
+      }
+    `,
     },
     color: 'background',
     border: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -413,7 +413,7 @@ export const hpe = deepFreeze({
         color: 'border-strong',
       },
       background: {
-        color: undefined,
+        color: 'background-contrast',
       },
     },
     color: 'background',
@@ -468,16 +468,13 @@ export const hpe = deepFreeze({
         }
       `,
     },
-    extend: ({ disabled, pad, theme }) => `
+    extend: ({ disabled, pad }) => `
     ${
       !disabled &&
-      !pad &&
+      pad &&
+      typeof pad !== 'object' &&
       `:hover {
-      background-color: ${
-        theme.global.colors['background-contrast'][
-          theme.dark ? 'dark' : 'light'
-        ]
-      };
+      background-color: unset;
     }`
     }
     font-weight: 500;

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -410,10 +410,10 @@ export const hpe = deepFreeze({
   checkBox: {
     hover: {
       border: {
-        color: undefined,
+        color: 'border-strong',
       },
       background: {
-        color: 'background-contrast',
+        color: undefined,
       },
     },
     color: 'background',
@@ -468,9 +468,10 @@ export const hpe = deepFreeze({
         }
       `,
     },
-    extend: ({ disabled, theme }) => `
+    extend: ({ disabled, pad, theme }) => `
     ${
       !disabled &&
+      !pad &&
       `:hover {
       background-color: ${
         theme.global.colors['background-contrast'][

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -415,12 +415,14 @@ export const hpe = deepFreeze({
       background: {
         color: 'background-contrast',
       },
+      // HPE Design System guidance states that pad="none" should be applied on CheckBox
+      // when its used outside of a FormField. We will apply this hover treatment in
+      // those instances.
       extend: ({ disabled, pad, theme }) => `
       ${
         !disabled &&
-        pad &&
-        typeof pad !== 'object' &&
-        `outline: solid ${
+        pad === 'none' &&
+        `border: 2px solid ${
           theme.global.colors['border-strong'][theme.dark ? 'dark' : 'light']
         };`
       }
@@ -478,11 +480,13 @@ export const hpe = deepFreeze({
         }
       `,
     },
+    // HPE Design System guidance states that pad="none" should be applied on CheckBox
+    // when its used outside of a FormField. We will apply this hover treatment in
+    // those instances.
     extend: ({ disabled, pad }) => `
     ${
       !disabled &&
-      pad &&
-      typeof pad !== 'object' &&
+      pad === 'none' &&
       `:hover {
       background-color: unset;
     }`


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR adds new hover treatment for `checkbox`
#### What testing has been done on this PR?
ariess-site
#### Any background context you want to provide?
**Not in form field**

- No padding
- Hover treatment border goes from default —> border-strong

**In FormField**

- Padding
- Hover treatment: background-contrast
- Hover treatment border goes from default —> border-strong

**In DataTable**

- Padding
- Hover treatment: background-contrast
- Hover treatment border goes from default —> border-strong

#### What are the relevant issues?
closes https://github.com/grommet/hpe-design-system/issues/2862
#### Screenshots (if appropriate)

https://user-images.githubusercontent.com/12522275/194620800-21bb5879-a939-487f-a833-d7ab920bc354.mov

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
