### PR TITLE
Account for color on primary button

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -249,6 +249,17 @@ export const hpe = deepFreeze({
       font: {
         weight: 700,
       },
+      // for primary button with color, use text-strong
+      // instead of text-primary-button which is hard-coded
+      // to "white" specifically for HPE green.
+      extend: ({ colorValue, primary, theme }) =>
+        colorValue && primary
+          ? `
+        color: ${
+          theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
+        };
+      `
+          : ``,
     },
     secondary: {
       border: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

For primary buttons, the label color is set to "white" so that it is consistent on the brand green regardless of theme mode. However, for primary + color buttons, we want the label color to respect the theme mode and use the appropriate mode of  `text-strong`.

#### What testing has been done on this PR?

Locally in Design System site (see screenshots below)

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

<img width="290" alt="Screen Shot 2022-10-04 at 9 21 05 AM" src="https://user-images.githubusercontent.com/12522275/193873122-209eb605-bfc6-4e31-bd5e-6bf30d71ce0c.png">
<img width="321" alt="Screen Shot 2022-10-04 at 9 21 00 AM" src="https://user-images.githubusercontent.com/12522275/193873133-d159d563-beb0-4036-8fd8-392d51b05079.png">


#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
