### PR TITLE
Dark mode adjustments

### DIFF
--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -12,49 +12,49 @@ export const colors = {
   'status-error': undefined,
   brand: 'green!',
   background: {
-    dark: '#263040',
+    dark: '#1C1C1C',
     light: '#FFFFFF',
   },
   'background-back': {
-    dark: '#263040',
-    light: '#EFEFEF',
+    dark: '#1C1C1C',
+    light: '#F7F7F7',
   },
   'background-front': {
-    dark: '#404B5C',
+    dark: '#222222',
     light: '#FFFFFF',
   },
   'background-contrast': {
-    dark: '#FFFFFF14',
+    dark: '#FFFFFF0F', // 6%
     light: '#0000000A',
   },
   icon: 'text',
   text: {
-    dark: '#C0CADC',
+    dark: '#FFFFFFE6', // 90%
     light: '#444444',
   },
   'text-strong': {
-    dark: '#FFFFFF',
+    dark: '#FFFFFFF5', // 96%
     light: '#000000',
   },
   'text-weak': {
-    dark: '#8C98AA',
+    dark: '#FFFFFF80', // 50%
     light: '#757575',
   },
   'text-xweak': {
-    dark: '#606B7D',
+    dark: '#FFFFFF33', // 20%
     light: '#BBBBBB',
   },
   border: {
-    dark: '#7887A1',
-    light: '#999999',
+    dark: '#FFFFFF5C', // 36%
+    light: '#0000005C', // 36%
   },
   'border-strong': {
-    dark: '#AFBCD2',
-    light: '#666666',
+    dark: '#FFFFFFB8', // 72%
+    light: '#000000B8', // 72%
   },
   'border-weak': {
-    dark: '#606B7D',
-    light: '#BBBBBB',
+    dark: '#FFFFFF1F', // 12%
+    light: '#0000001F', // 12%
   },
   control: 'green',
   'active-background': 'background-contrast',
@@ -75,7 +75,7 @@ export const colors = {
     light: '#17EBA0',
   },
   'status-unknown': {
-    dark: '#4F5F76',
+    dark: '#555555',
     light: '#CCCCCC',
   },
   'status-disabled': '#CCCCCC', // deprecated, does not support light and dark. use text-weak instead
@@ -115,16 +115,16 @@ export const colors = {
   },
   'yellow!': '#FEC901',
   'validation-critical': {
-    light: '#FED9D9',
-    dark: '#C54E4B5C',
+    light: '#FC61613D',
+    dark: '#CC1F1A4D', // 30%
   },
   'validation-ok': {
-    light: '#C7FAE8',
-    dark: '#00856759',
+    light: '#17EBA03D',
+    dark: '#17D0A64D',
   },
   'validation-warning': {
-    light: '#FFEFD2',
-    dark: '#9B63105C',
+    light: '#FFBC443D',
+    dark: '#D891284D',
   },
   'graph-0': 'orange!',
   'graph-1': 'blue!',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Makes adjustments to dark mode colors based on direction from Chris. The motivation is to lean away from the "blue-ish" tones of the current dark mode and go for a more neutral palette.

Additionally, validation colors were restored to use alpha -- the intent is that the color should "blend" with whatever background color it is on as opposed to being 100% opaque. Background-back for light mode was also adjusted to be slightly lighter.

#### What testing has been done on this PR?

Locally in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="1665" alt="Screen Shot 2022-10-05 at 8 00 06 PM" src="https://user-images.githubusercontent.com/12522275/194209713-0cc0dbee-69c1-4785-aeb4-41d1c17fd4cc.png">
<img width="1663" alt="Screen Shot 2022-10-05 at 7 58 31 PM" src="https://user-images.githubusercontent.com/12522275/194209716-1fbe149e-ef56-43a6-b73a-8d4e419c91bf.png">
<img width="504" alt="Screen Shot 2022-10-05 at 7 58 03 PM" src="https://user-images.githubusercontent.com/12522275/194209718-30b9e553-1484-4de4-9c98-510a0bd602e7.png">
<img width="1660" alt="Screen Shot 2022-10-05 at 7 57 43 PM" src="https://user-images.githubusercontent.com/12522275/194209719-58104f5e-aaf0-4922-846e-414fc54a9484.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
