### PR TITLE
Update FileInput message to use placeholder

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -783,7 +783,7 @@ export const hpe = deepFreeze({
       },
     },
     message: {
-      color: 'text-xweak',
+      color: 'placeholder',
     },
     pad: { horizontal: 'xsmall' },
     extend: 'border-radius: 4px;',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates FileInput message (placeholder text) to use `placeholder` to stay in sync with other input placeholder colors.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

Closes https://github.com/grommet/grommet-theme-hpe/issues/284

#### Screenshots (if appropriate)

<img width="465" alt="Screen Shot 2022-10-19 at 4 01 24 PM" src="https://user-images.githubusercontent.com/12522275/196820687-9c8683e5-fada-43c7-81ae-a4359191a5eb.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
