### PR TITLE
large size for avatar

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -201,6 +201,18 @@ export const hpe = deepFreeze({
       textDecoration: 'underline',
     },
   },
+  avatar: {
+    avatar: {
+      size: {
+        large: `${baseSpacing * 4}px`, // 96px
+      },
+      text: {
+        size: {
+          large: 'xxlarge', // 34px
+        },
+      },
+    },
+  },
   button: {
     default: {
       color: 'text-strong',

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -202,14 +202,12 @@ export const hpe = deepFreeze({
     },
   },
   avatar: {
-    avatar: {
+    size: {
+      large: `${baseSpacing * 4}px`, // 96px
+    },
+    text: {
       size: {
-        large: `${baseSpacing * 4}px`, // 96px
-      },
-      text: {
-        size: {
-          large: 'xxlarge', // 34px
-        },
+        large: 'xxlarge', // 34px
       },
     },
   },

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -207,7 +207,7 @@ export const hpe = deepFreeze({
     },
     text: {
       size: {
-        large: 'xxlarge', // 34px
+        large: 'xxlarge', // 36px
       },
     },
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR changes `large` to be 96px for Avatar size 
#### What testing has been done on this PR?
aries site
#### Any background context you want to provide?
designs call for 96px for large 
changes can also be seen here below in the deploy 
https://deploy-preview-2982--keen-mayer-a86c8b.netlify.app/components/avatar
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
