### PR TITLE
Update grouped menu theming

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1049,8 +1049,11 @@ export const hpe = deepFreeze({
       },
     },
     group: {
+      container: {
+        pad: 'none',
+      },
       separator: {
-        color: 'border-weak',
+        pad: 'none',
       },
     },
     icons: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1053,6 +1053,7 @@ export const hpe = deepFreeze({
         pad: 'none',
       },
       separator: {
+        color: 'border',
         pad: 'none',
       },
     },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updating grouped menu theming to remove pad around separator and to change separator color to `border`.

#### What testing has been done on this PR?
Tested locally in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/2964

#### Screenshots (if appropriate)

<img width="212" alt="Screen Shot 2022-10-20 at 4 31 32 PM" src="https://user-images.githubusercontent.com/12522275/197078211-d103525c-610c-4f0b-8864-fe9ff98720e6.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
Updated grouped Menu styling to remove padding around separator.