### PR TITLE
Use Brand Central font versions

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -106,28 +106,37 @@ export const hpe = deepFreeze({
       face: `
         @font-face {
           font-family: "Metric";
-          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/MetricHPE-Web-Regular.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Regular.woff2") format('woff2'),
+               url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Regular.woff") format('woff');
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/MetricHPE-Web-Bold.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Regular.woff2") format('woff2'),
+               url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Regular.woff") format('woff');
+          font-weight: 400;
+        }
+        @font-face {
+          font-family: "Metric";
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Bold.woff2") format('woff2'),
+               url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Bold.woff") format('woff');
           font-weight: 700;
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/MetricHPE-Web-Semibold.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Semibold.woff2") format('woff2'),
+               url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Semibold.woff") format('woff');
           font-weight: 600;
         }
-        // connecting with Artur's team to have the web version added to the CDN
         @font-face {
           font-family: "Metric";
-          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/Metric-Medium.woff2") format('woff2'),
-               url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/Metric-Medium.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Medium.woff2") format('woff2'),
+               url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Medium.woff") format('woff');
           font-weight: 500;
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/MetricHPE-Web-Light.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Light.woff2") format('woff2'),
+               url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe-web/MetricHPE-Web-Light.woff") format('woff');
           font-weight: 100;
         }`,
     },

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -106,26 +106,28 @@ export const hpe = deepFreeze({
       face: `
         @font-face {
           font-family: "Metric";
-          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Regular.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/MetricHPE-Web-Regular.woff") format('woff');
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Bold.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/MetricHPE-Web-Bold.woff") format('woff');
           font-weight: 700;
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPESemibold.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/MetricHPE-Web-Semibold.woff") format('woff');
           font-weight: 600;
         }
+        // connecting with Artur's team to have the web version added to the CDN
         @font-face {
           font-family: "Metric";
-          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Medium.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/Metric-Medium.woff2") format('woff2'),
+               url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/Metric-Medium.woff") format('woff');
           font-weight: 500;
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Light.woff") format('woff');
+          src: url("https://www.hpe.com/h41225/hfws-static/fonts/metric-hpe/MetricHPE-Web-Light.woff") format('woff');
           font-weight: 100;
         }`,
     },

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -106,31 +106,26 @@ export const hpe = deepFreeze({
       face: `
         @font-face {
           font-family: "Metric";
-          src: url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXS-Regular.woff2") format('woff2'),
-               url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXS-Regular.woff") format('woff');
+          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Regular.woff") format('woff');
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXS-Bold.woff2") format('woff2'),
-               url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXS-Bold.woff") format('woff');
+          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Bold.woff") format('woff');
           font-weight: 700;
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXSSemibold-Regular.woff2") format('woff2'),
-               url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXSSemibold-Regular.woff") format('woff');
+          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPESemibold.woff") format('woff');
           font-weight: 600;
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXSMedium-Regular.woff2") format('woff2'),
-               url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXSMedium-Regular.woff") format('woff');
+          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Medium.woff") format('woff');
           font-weight: 500;
         }
         @font-face {
           font-family: "Metric";
-          src: url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXSLight-Regular.woff2") format('woff2'),
-               url("https://d3hq6blov2iije.cloudfront.net/fonts/HPEXS-Metric-Fonts/MetricHPEXSLight-Regular.woff") format('woff');
+          src: url("https://hpefonts.s3.amazonaws.com/web/MetricHPE-Web-Light.woff") format('woff');
           font-weight: 100;
         }`,
     },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Based on outcomes of https://github.com/grommet/hpe-design-system/issues/2990, reverting the theme to point to brand central font version. The URLs were provided by Artur's team. I had to explicitly define regular as font-weight 400 otherwise it wasn't applying it.

#### What testing has been done on this PR?
Tested locally in the site on Mac Chrome, Windows Edge:

Mac Chrome:
<img width="512" alt="Screen Shot 2023-01-27 at 3 36 21 PM" src="https://user-images.githubusercontent.com/12522275/215225908-621ee87c-3785-465d-a9e4-0c4737665c9f.png">


New font, Windows Edge (notice how the "i" is differentiable from "l", j has a visibly separate dot)

<img width="494" alt="Screen Shot 2023-01-27 at 3 38 54 PM" src="https://user-images.githubusercontent.com/12522275/215225926-078fc0b7-e939-4e5a-896c-7e07f06c0fcf.png">

#### Any background context you want to provide?

#### What are the relevant issues?

Closes https://github.com/grommet/hpe-design-system/issues/2990

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
