### PR TITLE
Product typography

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1314,11 +1314,11 @@ export const hpe = deepFreeze({
       height: '48px',
       maxWidth: '854px',
     },
-    // extend: ({ size }) => {
-    //   if (['large', 'xlarge', 'xxlarge'].includes(size))
-    //     return 'font-weight: 300;';
-    //   return '';
-    // },
+    extend: ({ size }) => {
+      if (['large', 'xlarge', 'xxlarge'].includes(size))
+        return 'font-weight: 300;';
+      return '';
+    },
   },
   radioButton: {
     border: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -901,70 +901,70 @@ export const hpe = deepFreeze({
     level: {
       1: {
         small: {
-          size: '48px', // size: '36px',
-          height: '48px', // height: '42px',
+          size: '24px', // size: '48px', // size: '36px',
+          height: '24px', // height: '48px', // height: '42px',
           maxWidth: '854px',
         },
         medium: {
-          size: '72px', // size: '53px',
-          height: '72px', // height: '59px',
+          size: '36px', // size: '72px', // size: '53px',
+          height: '36px', // height: '72px', // height: '59px',
           maxWidth: '1277px',
         },
         large: {
-          size: '96px', // size: '88px',
-          height: '96px', // height: '94px',
+          size: '48px', // size: '96px', // size: '88px',
+          height: '48px', // height: '96px', // height: '94px',
           maxWidth: '2122px',
         },
         xlarge: {
-          size: '120px', // size: '124px',
-          height: '120px', // height: '130px',
+          size: '60px', // size: '120px', // size: '124px',
+          height: '60px', // height: '120px', // height: '130px',
           maxWidth: '2966px',
         },
       },
       2: {
         small: {
-          size: '36px', // size: '31px',
-          height: '36px', // height: '37px',
+          size: '18px', // size: '36px', // size: '31px',
+          height: '18px', // height: '36px', // height: '37px',
           maxWidth: '749px',
         },
         medium: {
-          size: '48px', // size: '44px',
-          height: '48px', // height: '50px',
+          size: '24px', // size: '48px', // size: '44px',
+          height: '24px', // height: '48px', // height: '50px',
           maxWidth: '1066px',
         },
         large: {
-          size: '72px', // size: '58px',
-          height: '72px', // height: '64px',
+          size: '36px', // size: '72px', // size: '58px',
+          height: '36px', // height: '72px', // height: '64px',
           maxWidth: '1382px',
         },
         xlarge: {
-          size: '96px', // size: '71px',
-          height: '96px', // height: '77px',
+          size: '48px', // size: '96px', // size: '71px',
+          height: '48px', // height: '96px', // height: '77px',
           maxWidth: '1699px',
         },
       },
       3: {
+        font: {
+          weight: 500,
+        },
         small: {
-          // Design file call for h3 small to bump up to font-weight 500,
-          // however the theme does not currently support this at the 'size'
-          // level, only for at the 'level' level.
-          size: '24px', // size: '27px',
-          height: '24px', // height: '33px',
+          size: '16px', // size: '24px', // size: '27px',
+          height: '16px', // height: '24px', // height: '33px',
           maxWidth: '643px',
         },
         medium: {
-          size: '36px', // size: '36px',
-          height: '36px', // height: '42px',
+          size: '18px', // size: '36px', // size: '36px',
+          height: '18px', // height: '36px', // height: '42px',
           maxWidth: '854px',
         },
         large: {
-          size: '48px', // size: '44px',
-          height: '48px', // height: '50px',
+          size: '24px', // size: '48px', // size: '44px',
+          height: '24px', // height: '48px', // height: '50px',
           maxWidth: '1066px',
         },
         xlarge: {
-          size: '72px', // size: '53px',
-          height: '72px', // height: '59px',
+          size: '36px', // size: '72px', // size: '53px',
+          height: '36px', // height: '72px', // height: '59px',
           maxWidth: '1277px',
         },
       },
@@ -973,25 +973,23 @@ export const hpe = deepFreeze({
           weight: 500,
         },
         small: {
-          size: '18px', // size: '22px',
-          height: '18px', // height: '28px',
+          size: '14px', // size: '18px', // size: '22px',
+          height: '14px', // height: '18px', // height: '28px',
           maxWidth: '538px',
         },
         medium: {
-          size: '24px', // size: '27px',
-          height: '24px', // height: '33px',
+          size: '16px', // size: '24px', // size: '27px',
+          height: '16px', // height: '24px', // height: '33px',
           maxWidth: '643px',
         },
-        // This should be a weight of 400, while all smaller sizes 500.
         large: {
-          size: '36px', // size: '31px',
-          height: '36px', // height: '37px',
+          size: '18px', // size: '36px', // size: '31px',
+          height: '18px', // height: '36px', // height: '37px',
           maxWidth: '749px',
         },
-        // This should be a weight of 400, while all smaller sizes 500.
         xlarge: {
-          size: '48px', // size: '36px',
-          height: '48px', // height: '42px',
+          size: '24px', // size: '48px', // size: '36px',
+          height: '24px', // height: '48px', // height: '42px',
           maxWidth: '854px',
         },
       },
@@ -1000,30 +998,29 @@ export const hpe = deepFreeze({
           weight: 500,
         },
         small: {
-          size: '16px', // size: '16px',
-          height: '16px', // height: '22px',
+          size: '14px', // size: '16px', // size: '16px',
+          height: '14px', // height: '16px', // height: '22px',
           maxWidth: '379px',
         },
         medium: {
-          size: '18px', // size: '16px',
-          height: '18px', // height: '22px',
+          size: '14px', // size: '18px', // size: '16px',
+          height: '14px', // height: '18px', // height: '22px',
           maxWidth: '379px',
         },
         large: {
-          size: '24px', // size: '16px',
-          height: '24px', // height: '22px',
+          size: '16px', // size: '24px', // size: '16px',
+          height: '16px', // height: '24px', // height: '22px',
           maxWidth: '379px',
         },
         xlarge: {
-          // This should be a weight of 400, while all smaller sizes 500.
-          size: '36px', // size: '16px',
-          height: '36px', // height: '22px',
+          size: '18px', // size: '36px', // size: '16px',
+          height: '18px', // height: '36px', // height: '22px',
           maxWidth: '379px',
         },
       },
       6: {
         font: {
-          weight: 500,
+          weight: 600,
         },
         small: {
           size: '14px', // size: '14px',
@@ -1031,30 +1028,36 @@ export const hpe = deepFreeze({
           maxWidth: '326px',
         },
         medium: {
-          size: '16px', // size: '14px',
-          height: '16px', // height: '20px',
+          size: '14px', // size: '16px', // size: '14px',
+          height: '14px', // height: '16px', // height: '20px',
           maxWidth: '326px',
         },
         large: {
-          size: '18px', // size: '14px',
-          height: '18px', // height: '20px',
+          size: '14px', // size: '18px', // size: '14px',
+          height: '14px', // height: '18px', // height: '20px',
           maxWidth: '326px',
         },
         xlarge: {
-          size: '24px', // size: '14px',
-          height: '24px', // height: '20px',
+          size: '16px', // size: '24px', // size: '14px',
+          height: '16px', // height: '24px', // height: '20px',
           maxWidth: '326px',
         },
       },
     },
     extend: ({ level, size }) => {
       let fontWeight = '';
-      if (level === 3 && size === 'small') {
+      if ([1, 2, 3].includes(level) && size === 'small') {
         fontWeight = 'font-weight: 500;';
-      } else if (level === 4 && ['large', 'xlarge'].includes(size)) {
+      } else if ([2, 3].includes(level) && size === 'medium') {
+        fontWeight = 'font-weight: 500;';
+      } else if (level === 3 && size === 'xlarge') {
         fontWeight = 'font-weight: 400;';
-      } else if (level === 5 && size === 'xlarge') {
-        fontWeight = 'font-weight: 400;';
+      } else if (level === 4 && size === 'small') {
+        fontWeight = 'font-weight: 600;';
+      } else if (level === 5 && ['small', 'medium'].includes(size)) {
+        fontWeight = 'font-weight: 600;';
+      } else if (level === 6 && size === 'xlarge') {
+        fontWeight = 'font-weight: 500;';
       }
       return fontWeight;
     },
@@ -1286,41 +1289,36 @@ export const hpe = deepFreeze({
   },
   paragraph: {
     small: {
-      // weight needs to be modified at the size level
       size: '16px',
       height: '20px',
       maxWidth: '379px',
     },
     medium: {
-      // weight needs to be modified at the size level
       size: '18px',
       height: '22px',
       maxWidth: '432px',
     },
     large: {
-      // weight needs to be modified at the size level by bumping down to 300
       size: '24px',
       height: '30px',
       maxWidth: '538px',
     },
     xlarge: {
-      // weight needs to be modified at the size level by bumping down to 300
       size: '36px',
       height: '42px',
       maxWidth: '643px',
     },
     // xxlarge is not part of Chris's type exploration
     xxlarge: {
-      // weight needs to be modified at the size level by bumping down to 300
       size: '42px',
       height: '48px',
       maxWidth: '854px',
     },
-    extend: ({ size }) => {
-      if (['large', 'xlarge', 'xxlarge'].includes(size))
-        return 'font-weight: 300;';
-      return '';
-    },
+    // extend: ({ size }) => {
+    //   if (['large', 'xlarge', 'xxlarge'].includes(size))
+    //     return 'font-weight: 300;';
+    //   return '';
+    // },
   },
   radioButton: {
     border: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Apparently the typography direction is recommending two font scales:
- One for web (larger)
- One for product (smaller)

This PR to merge into NEXT is adjusting Heading sizes to fit the [product scale](https://www.figma.com/file/DzR2LCNtbuZvomp1DOOGMR/HPE-GreenLake-Brand-Refresh?node-id=616%3A31632&t=Q1h8JGskLnTRtzoc-4).

Leaving the "web scale values" commented out so that we can reapply them easily.

In the longer term, if we are going to be supporting multiple scales, we might want to consider a new theme repo for `grommet-theme-hpe-web` or something along those lines. This could be a `const hpeWeb = deepFreeze({ // font size overrides }, hpe);`
