### PR TITLE
Apply iconOnly and layer backdropFilter enhancements

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -429,6 +429,9 @@ export const hpe = deepFreeze({
           vertical: '6px',
           horizontal: '18px',
         },
+        iconOnly: {
+          pad: '6px',
+        },
         toolbar: {
           pad: {
             vertical: '4px',
@@ -444,17 +447,8 @@ export const hpe = deepFreeze({
           vertical: '6px',
           horizontal: '18px',
         },
-        'cta-primary': {
-          pad: {
-            vertical: '6px',
-            horizontal: '16px',
-          },
-        },
-        'cta-alternate': {
-          pad: {
-            vertical: '6px',
-            horizontal: '16px',
-          },
+        iconOnly: {
+          pad: '6px',
         },
         toolbar: {
           border: {
@@ -474,17 +468,8 @@ export const hpe = deepFreeze({
           vertical: '8px',
           horizontal: '24px',
         },
-        'cta-primary': {
-          pad: {
-            vertical: '8px',
-            horizontal: '20px',
-          },
-        },
-        'cta-alternate': {
-          pad: {
-            vertical: '8px',
-            horizontal: '20px',
-          },
+        iconOnly: {
+          pad: '12px',
         },
         toolbar: {
           pad: {
@@ -517,14 +502,6 @@ export const hpe = deepFreeze({
     },
     extend: (props) => {
       let style = '';
-      // icon only specific padding still in progress
-      if (!props.hasLabel && !props.plain && props.kind !== 'toolbar') {
-        if (props.sizeProp === 'medium' || !props.sizeProp) {
-          if (props.kind === 'secondary') style += 'padding: 4px;';
-          else style += 'padding: 6px;';
-        } else if (props.kind === 'secondary') style += 'padding: 10px;';
-        else style += 'padding: 12px;';
-      }
       if (props.sizeProp === 'small') {
         style += 'line-height: 24px;';
       }
@@ -1033,10 +1010,9 @@ export const hpe = deepFreeze({
     container: {
       elevation: 'large',
     },
-    // temp CSS selector to target Layer overlay
-    extend: '> div { backdrop-filter: blur(12px); }',
     overlay: {
       background: '#0000001F',
+      backdropFilter: `blur(12px)`,
     },
     /* HPE Global Header/Footer Service a.k.a. HPE Common HFWS sets the header
      * at a z-index of 101. This adjustment allows for Layer modals and side-drawers


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `iconOnly` padding for button (values may need to be refined in relation to Chris's explorations on icon sizing, but setting this for now to replace what we currently have in extend).

Also, removed unnecessary overrides for cta-primary/alternate that were lingering from a previous merge.

Adds `backdropFilter` to Layer overlay and removes extend.

NOTE: Toolbar icon only button padding changes with this, but in discussion with Eric we felt like this change was reasonable and in the spirit of the new direction. Feedback welcome.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="1090" alt="Screen Shot 2023-02-03 at 2 44 53 PM" src="https://user-images.githubusercontent.com/12522275/216725159-13b9dfd3-176c-4076-aac6-ff9500a8f02e.png">

<img width="1679" alt="Screen Shot 2023-02-03 at 2 50 02 PM" src="https://user-images.githubusercontent.com/12522275/216725771-e27aab92-faf6-4f8d-9068-5facedecd095.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
