### PR TITLE
Add theme adjustments to align with latest discussions

### DIFF
--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -64,7 +64,7 @@ export const colors = {
   'active-background': 'background-contrast',
   'active-text': 'text',
   'disabled-text': 'text-weak', // deprecated, use text-weak instead
-  'selected-background': 'green',
+  'selected-background': 'green!',
   'selected-text': 'text-strong',
   'status-critical': {
     dark: '#D04F4E',

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -65,7 +65,7 @@ export const colors = {
   'active-text': 'text',
   'disabled-text': 'text-weak', // deprecated, use text-weak instead
   'selected-background': 'green!',
-  'selected-text': 'text-strong',
+  'selected-text': 'text-primary-button', // necessary to meet color contrast on HPE green background
   'status-critical': {
     dark: '#D04F4E',
     light: '#FC5A5A',

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -274,13 +274,6 @@ export const hpe = deepFreeze({
     },
   },
   button: {
-    icon: {
-      size: {
-        small: '16px',
-        medium: '18px',
-        large: '24px',
-      },
-    },
     'cta-primary': {
       background: { color: 'brand' },
       border: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1428,14 +1428,13 @@ export const hpe = deepFreeze({
   },
   tabs: {
     header: {
+      alignSelf: 'start',
       border: {
         side: 'bottom',
         size: 'xsmall',
         color: 'border-weak',
       },
     },
-    // temp extend, grommet enhancement should be considered
-    extend: 'div[role=tablist] { align-self: start; }',
     step: {
       xsmall: 1,
       xlarge: 3,

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1406,11 +1406,12 @@ export const hpe = deepFreeze({
       // "vertical" only applies to top
       bottom: 'small',
       top: 'small',
-      horizontal: 'medium',
+      // align horizontal pad with button
+      horizontal: '18px',
     },
     margin: {
       // bring the overall tabs border behind invidual tab borders
-      vertical: '-2px',
+      vertical: '-1px',
       horizontal: 'none',
     },
     extend: `
@@ -1425,10 +1426,12 @@ export const hpe = deepFreeze({
     header: {
       border: {
         side: 'bottom',
-        size: 'small',
-        color: 'none',
+        size: 'xsmall',
+        color: 'border-weak',
       },
     },
+    // temp extend, grommet enhancement should be considered
+    extend: 'div[role=tablist] { align-self: start; }',
     step: {
       xsmall: 1,
       xlarge: 3,

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -516,10 +516,18 @@ export const hpe = deepFreeze({
         },
       },
     },
-    extend: (props) => {
+    extend: ({ sizeProp }) => {
+      // necessary so primary label is accessible on HPE green background
+      const fontSize = '19px';
+      const lineHeight = '24px';
       let style = '';
-      if (props.sizeProp === 'small') {
-        style += 'line-height: 24px;';
+      // keep reasonable click target for small button
+      if (sizeProp === 'small') {
+        style += `line-height: ${lineHeight};`;
+      }
+      if (sizeProp === 'medium' || sizeProp === undefined) {
+        style += `font-size: ${fontSize};
+        line-height: ${lineHeight};`;
       }
       return style;
     },

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -237,31 +237,43 @@ export const hpe = deepFreeze({
     },
   },
   anchor: {
-    color: 'brand',
-    textDecoration: 'none',
+    color: 'text-strong',
+    textDecoration: 'underline',
     fontWeight: 700,
     gap: 'xsmall',
     hover: {
       textDecoration: 'underline',
     },
-    // extend is necessary given current grommet theme structure
-    // this block ensures that xsmall/small anchors receive text-strong
-    // color and underline when there's no label.
-    // This extend block can be removed once grommet theme structure is enhanced.
-    extend: ({ hasIcon, size, theme }) => `
-    ${
-      ['xsmall', 'small'].includes(size)
-        ? `color: ${
-            theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
-          };`
-        : ''
-    };
-    ${
-      ['xsmall', 'small'].includes(size) && hasIcon !== true
-        ? 'text-decoration: underline;'
-        : ''
-    };
-    `,
+    size: {
+      large: {
+        color: 'brand',
+        textDecoration: 'none',
+      },
+      xlarge: {
+        color: 'brand',
+        textDecoration: 'none',
+      },
+      xxlarge: {
+        color: 'brand',
+        textDecoration: 'none',
+      },
+      '3xl': {
+        color: 'brand',
+        textDecoration: 'none',
+      },
+      '4xl': {
+        color: 'brand',
+        textDecoration: 'none',
+      },
+      '5xl': {
+        color: 'brand',
+        textDecoration: 'none',
+      },
+      '6xl': {
+        color: 'brand',
+        textDecoration: 'none',
+      },
+    },
   },
   avatar: {
     size: {
@@ -439,7 +451,7 @@ export const hpe = deepFreeze({
           horizontal: '18px',
         },
         iconOnly: {
-          pad: '6px',
+          pad: '9px',
         },
         toolbar: {
           pad: {
@@ -457,7 +469,7 @@ export const hpe = deepFreeze({
           horizontal: '18px',
         },
         iconOnly: {
-          pad: '6px',
+          pad: '9px',
         },
         toolbar: {
           border: {
@@ -478,7 +490,7 @@ export const hpe = deepFreeze({
           horizontal: '24px',
         },
         iconOnly: {
-          pad: '12px',
+          pad: '15px',
         },
         toolbar: {
           pad: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1025,6 +1025,9 @@ export const hpe = deepFreeze({
   },
   icon: {
     size: {
+      small: '16px',
+      medium: '18px',
+      large: '24px',
       xxlarge: '166px',
     },
   },

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -274,6 +274,13 @@ export const hpe = deepFreeze({
     },
   },
   button: {
+    icon: {
+      size: {
+        small: '16px',
+        medium: '18px',
+        large: '24px',
+      },
+    },
     'cta-primary': {
       background: { color: 'brand' },
       border: {
@@ -336,8 +343,7 @@ export const hpe = deepFreeze({
     },
     toolbar: {
       border: {
-        color: 'border',
-        width: '1px',
+        radius: '6px',
       },
       color: 'text-strong',
       font: {
@@ -373,6 +379,9 @@ export const hpe = deepFreeze({
       option: {
         background: 'selected-background',
         color: 'selected-text',
+        font: {
+          weight: 700,
+        },
       },
     },
     hover: {
@@ -591,7 +600,7 @@ export const hpe = deepFreeze({
       extend: ({ theme, checked, indeterminate }) => `
       background-color: ${
         checked || indeterminate
-          ? theme.global.colors.green[theme.dark ? 'dark' : 'light']
+          ? theme.global.colors['green!']
           : theme.global.colors.background[theme.dark ? 'dark' : 'light']
       };
       ${(checked || indeterminate) && 'border: none;'}
@@ -599,9 +608,7 @@ export const hpe = deepFreeze({
     },
     icon: {
       extend: ({ theme }) => `stroke-width: 2px;
-      stroke: ${
-        theme.global.colors['text-strong'][theme.dark ? 'dark' : 'light']
-      }`,
+      stroke: ${theme.global.colors['text-primary-button']}`,
     },
     gap: 'small',
     label: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This PR:
- Adjusts icon sizing to align with font-size as opposed to line-height at each size
- Restores Button extend for label size to 19px to meet AA contrast requirement
- Removes border from toolbar buttons, but leaves 6px rounding to have parody with inputs they are presented alongside
- Adjusts checkbox, radiobutton, and select "selected" state to use brand green. To meet color contrast for Select selected option, increases font-weight on selected item to 700 (aligns with Button).
- Tab styling based on [conclusions in this file](https://www.figma.com/file/KYjfAybRakWLOe2GLAHDHV/Tabs-variations?node-id=0%3A1&t=uMKWBZm1a62HvxIs-0).

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

Related to #308 

#### Screenshots (if appropriate)

<img width="1141" alt="Screen Shot 2023-02-17 at 8 19 50 AM" src="https://user-images.githubusercontent.com/12522275/219707838-fb696345-82eb-4fff-b395-db874c93ab1a.png">

<img width="381" alt="Screen Shot 2023-02-17 at 8 18 58 AM" src="https://user-images.githubusercontent.com/12522275/219707769-8aa0c97a-44c2-43c7-b553-09a400447299.png">

<img width="456" alt="Screen Shot 2023-02-17 at 8 20 20 AM" src="https://user-images.githubusercontent.com/12522275/219707923-1f698b45-ed53-40b6-9995-6df5fc13536b.png">

<img width="1172" alt="Screen Shot 2023-02-21 at 4 11 07 PM" src="https://user-images.githubusercontent.com/12522275/220750236-4128f7cc-b0f9-4532-801e-db52bad79e21.png">


#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
