### PR TITLE
Add release-audit-stable ci-cd step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,16 @@ jobs:
             git config --global user.name "Grommet Community Bot"
             git config --global user.email "grommet@hpe.com"
             yarn release-next-stable
+  release-audit-stable:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/grommet-ci
+      - run:
+          command: |
+            git config --global user.name "Grommet Community Bot"
+            git config --global user.email "grommet@hpe.com"
+            yarn release-audit-stable
   release-gh-pages:
     <<: *defaults
     steps:
@@ -101,6 +111,7 @@ workflows:
               ignore:
                 - stable
                 - NEXT-stable
+                - AUDIT-stable
                 - gh-pages
       - build:
           requires:
@@ -112,6 +123,7 @@ workflows:
               ignore:
                 - stable
                 - NEXT-stable
+                - AUDIT-stable
                 - gh-pages
       - release-stable:
           requires:
@@ -129,6 +141,14 @@ workflows:
             branches:
               only:
                 - NEXT
+      - release-audit-stable:
+          requires:
+            - lint
+            - build
+          filters:
+            branches:
+              only:
+                - AUDIT
       - release-gh-pages:
           requires:
             - lint

--- a/README.md
+++ b/README.md
@@ -44,3 +44,17 @@ _NOTE: This branch should never be used in production as it contains work in pro
 ```
 "grommet-theme-hpe": "https://github.com/grommet/grommet-theme-hpe/tarball/NEXT-stable",
 ```
+
+## AUDIT-stable
+
+The `AUDIT-stable` branch is used to increase UI consistency and velocity across HPE applications by ensuring implementations use theme design tokens and avoid use of custom style overrides. Clean implmentations allow for evolving HPE brand styles and best practices to be seamlessly incorporated into HPE applications.
+
+This branch serves as tool to help audit implementations by applying visual highlights to UI components whose implementations may prevent theme styles from being applied cleanly. An accompanying legend provides each highlight paired with an issue description and suggested remedy.
+
+The contents of `AUDIT` branch are available on `AUDIT-stable`. From your package.json point to AUDIT-stable.
+
+_NOTE: This branch should never be used in production as it is a branch meant for use as a tool to help teams maintain best practices for consuming `grommet-theme-hpe`._
+
+```
+"grommet-theme-hpe": "https://github.com/grommet/grommet-theme-hpe/tarball/AUDIT-stable",
+```

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "prettier": "pretty-quick --staged",
     "release-stable": "babel-node ./tools/release-stable",
     "release-next-stable": "babel-node ./tools/release-next-stable",
+    "release-audit-stable": "babel-node ./tools/release-audit-stable",
     "jsonify": "babel-node ./tools/convert-to-json > dist/grommet-theme-hpe.json",
     "release-gh-pages": "babel-node ./tools/release-gh-pages"
   },

--- a/tools/release-audit-stable.js
+++ b/tools/release-audit-stable.js
@@ -1,0 +1,28 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-console */
+import del from 'del';
+import fs from 'fs-extra';
+import path from 'path';
+import { simpleGit as git } from 'simple-git';
+
+const repoURL = `https://${process.env.GH_TOKEN}@github.com/grommet/grommet-theme-hpe`;
+const localFolder = path.resolve('.tmp/grommet-theme-hpe');
+const localDist = path.resolve('dist');
+
+if (process.env.CI) {
+  del(localFolder).then(() => {
+    git()
+      .clone(repoURL, localFolder)
+      .then(() => git(localFolder).checkout('AUDIT-stable'))
+      .then(() => del([`${localFolder}/**/*`]))
+      .then(() => fs.copy(localDist, localFolder))
+      .then(() => git(localFolder).add(['--all', '.']))
+      .then(() => git(localFolder).commit('AUDIT-stable updated'))
+      .then(() => git(localFolder).push('origin', 'AUDIT-stable'))
+      .catch((err) => console.error('failed: ', err));
+  });
+} else {
+  console.warn(
+    'Skipping release. Release:audit-stable task should be executed by CI only.',
+  );
+}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Closes https://github.com/grommet/hpe-design-system/issues/3155 by adding `release-audit-stable` ci/cd step for CircleCI to run against the AUDIT branch.

#### What testing has been done on this PR?

#### Any background context you want to provide?

Intended to aid conducting brand and design system audits.

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/3155

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
