### PR TITLE
Remove extra padding from notification icon container

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1129,11 +1129,6 @@ export const hpe = deepFreeze({
     container: {
       round: 'xsmall',
     },
-    iconContainer: {
-      pad: {
-        top: 'xxsmall',
-      },
-    },
     global: {
       container: {
         round: 'none',


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where icons in notifications are not vertically centered.

Before:
<img width="698" alt="Screen Shot 2023-03-09 at 4 39 51 PM" src="https://user-images.githubusercontent.com/54560994/224773090-eccce9af-b431-4132-b6f4-381ea6ce2877.png">


After:
<img width="601" alt="Screen Shot 2023-03-13 at 10 58 09 AM" src="https://user-images.githubusercontent.com/54560994/224773123-68a2e345-6050-4894-885a-929363ca8cf1.png">


#### What testing has been done on this PR?
Tested by adjusting the theme in grommet's Notification/Status story
#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet-theme-hpe/issues/319

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backwards compatible

#### How should this PR be communicated in the release notes?
