### PR TITLE
Adjust select icon margin

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1392,20 +1392,19 @@ export const hpe = deepFreeze({
         input {
           cursor: default;
         }`}
-
-        // on small screens, Select responsive padding
-        // sizes down which brings the icon too tight with
-        // edge of control. add padding to retain spacing
-        @media only screen and (max-width: 768px) {
-          svg {
-            padding-right: 6px;
-          }
-        }
       `,
     },
     icons: {
       color: 'text',
       down: Down,
+      margin: {
+        left: 'small',
+        // setting right margin to 12px because on small
+        // screens, Select responsive padding sizes down
+        // which brings the icon too tight with edge of
+        // control.
+        right: '12px',
+      },
       up: Up,
     },
     options: undefined,


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where SelectMultiple `showSelectedInline` checkmark icons were not centered on small screens.

Before:
<img width="273" alt="Screen Shot 2023-03-13 at 12 56 17 PM" src="https://user-images.githubusercontent.com/54560994/224802376-c691af61-af04-48e5-823e-283cd89e4578.png">

After:
<img width="283" alt="Screen Shot 2023-03-13 at 12 55 51 PM" src="https://user-images.githubusercontent.com/54560994/224802404-aea93118-9f81-47c7-9543-99ee61b3fdc6.png">

#### What testing has been done on this PR?
Tested by adjusting the theme in the grommet SelectMultiple/ShowSelectedInline story

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet-theme-hpe/issues/319

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible

#### How should this PR be communicated in the release notes?
