### PR TITLE
Set default radius to 2em

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -322,6 +322,7 @@ export const hpe = deepFreeze({
     },
     default: {
       color: 'text-strong',
+      // necessary so badge overlaps label/icon
       border: undefined,
       font: {
         weight: 700,
@@ -436,13 +437,6 @@ export const hpe = deepFreeze({
       },
     },
     color: 'text-strong',
-    border: {
-      radius: '6px',
-    },
-    padding: {
-      vertical: '4px',
-      horizontal: '22px',
-    },
     size: {
       small: {
         border: {
@@ -456,6 +450,9 @@ export const hpe = deepFreeze({
           pad: '9px',
         },
         toolbar: {
+          border: {
+            radius: '6px',
+          },
           pad: {
             vertical: '4px',
             horizontal: '8px',
@@ -495,6 +492,9 @@ export const hpe = deepFreeze({
           pad: '12px',
         },
         toolbar: {
+          border: {
+            radius: '8px',
+          },
           pad: {
             vertical: '8px',
             horizontal: '16px',

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -305,9 +305,6 @@ export const hpe = deepFreeze({
     },
     'cta-primary': {
       background: { color: 'brand' },
-      border: {
-        radius: '2em',
-      },
       color: 'text-primary-button',
       font: { weight: 'bold' },
       icon: <Hpe />,
@@ -316,9 +313,6 @@ export const hpe = deepFreeze({
     },
     'cta-alternate': {
       background: 'background-cta-alternate',
-      border: {
-        radius: '2em',
-      },
       color: 'text-strong',
       font: {
         weight: 'bold',
@@ -328,9 +322,7 @@ export const hpe = deepFreeze({
     },
     default: {
       color: 'text-strong',
-      border: {
-        radius: '2em',
-      },
+      border: undefined,
       font: {
         weight: 700,
       },
@@ -339,9 +331,6 @@ export const hpe = deepFreeze({
     primary: {
       background: {
         color: 'brand',
-      },
-      border: {
-        radius: '2em',
       },
       color: 'text-primary-button',
       font: {
@@ -352,7 +341,6 @@ export const hpe = deepFreeze({
     secondary: {
       border: {
         color: 'brand',
-        radius: '2em',
         width: '2px',
       },
       color: 'text-strong',
@@ -458,7 +446,7 @@ export const hpe = deepFreeze({
     size: {
       small: {
         border: {
-          radius: '6px',
+          radius: '2em',
         },
         pad: {
           vertical: '6px',
@@ -476,7 +464,7 @@ export const hpe = deepFreeze({
       },
       medium: {
         border: {
-          radius: '6px',
+          radius: '2em',
         },
         pad: {
           vertical: '6px',
@@ -497,7 +485,7 @@ export const hpe = deepFreeze({
       },
       large: {
         border: {
-          radius: '8px',
+          radius: '2em',
         },
         pad: {
           vertical: '8px',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Instead of defining on each kind, set default button radius to 2em. This allows us to leave `default` button radius as `undefined` so the badge aligns to the label/icon instead.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

<img width="1379" alt="Screen Shot 2023-03-13 at 6 48 48 PM" src="https://user-images.githubusercontent.com/12522275/224864163-197b2517-2479-44a6-8aaa-bfe203584d22.png">


#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
