### PR TITLE
Remove extra margin from tag remove button

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1524,11 +1524,6 @@ export const hpe = deepFreeze({
     value: {
       weight: 500,
     },
-    remove: {
-      margin: {
-        top: 'xxsmall',
-      },
-    },
   },
   text: {
     xsmall: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
There is an extra 3px top margin on the close button for tags. This PR removes the extra margin.

<img width="121" alt="Screen Shot 2023-03-14 at 10 26 03 AM" src="https://user-images.githubusercontent.com/54560994/225072152-3393463f-e4f9-4e5e-baed-494653c08eb8.png">

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?
https://github.com/grommet/grommet-theme-hpe/issues/319

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible
#### How should this PR be communicated in the release notes?
