### PR TITLE
Align badge color to button label color

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -295,6 +295,10 @@ export const hpe = deepFreeze({
   button: {
     badge: {
       align: 'container',
+      container: {
+        // align badge background to button label color
+        background: 'text-strong',
+      },
       size: {
         medium: '18px',
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Aligns button badge color to button label color.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
<img width="1160" alt="Screen Shot 2023-03-20 at 11 56 54 AM" src="https://user-images.githubusercontent.com/12522275/226439152-ca99081c-67f8-42f6-a089-104336d7607d.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
