### PR TITLE
Update DataTable contract/expand icons

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -747,6 +747,8 @@ export const hpe = deepFreeze({
     icons: {
       ascending: Ascending,
       descending: Descending,
+      contract: () => <Up height="medium" />,
+      expand: () => <Down height="medium" />,
       sortable: Unsorted,
     },
     pinned: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -745,7 +745,7 @@ export const hpe = deepFreeze({
       pad: { horizontal: 'small', vertical: 'xsmall' },
     },
     icons: {
-      ascending: Ascending,
+      ascending: () => <Ascending size="large" />,
       descending: Descending,
       contract: () => <Up height="medium" />,
       expand: () => <Down height="medium" />,

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -749,7 +749,7 @@ export const hpe = deepFreeze({
       descending: () => <Descending size="large" />,
       contract: () => <Up height="medium" />,
       expand: () => <Down height="medium" />,
-      sortable: Unsorted,
+      sortable: () => <Unsorted size="large" />,
     },
     pinned: {
       header: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -746,7 +746,7 @@ export const hpe = deepFreeze({
     },
     icons: {
       ascending: () => <Ascending size="large" />,
-      descending: Descending,
+      descending: () => <Descending size="large" />,
       contract: () => <Up height="medium" />,
       expand: () => <Down height="medium" />,
       sortable: Unsorted,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates the DataTable contract/expand icons for `groupBy` to use Down/Up instead of form icons. Height "medium" ensures the icon is vertically-aligned with the other content in the row.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

<img width="953" alt="Screen Shot 2023-03-21 at 6 08 57 PM" src="https://user-images.githubusercontent.com/12522275/226777313-2adc12de-f620-4e35-9c30-82a75afaa501.png">


#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
