### PR TITLE
Update size of datatable icons

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -745,9 +745,9 @@ export const hpe = deepFreeze({
       pad: { horizontal: 'small', vertical: 'xsmall' },
     },
     icons: {
-      ascending: Ascending,
-      descending: Descending,
-      sortable: Unsorted,
+      ascending: () => <Ascending size="large" />,
+      descending: () => <Descending size="large" />,
+      sortable: () => <Unsorted size="large" />,
     },
     pinned: {
       header: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates size of DataTable icons to be proportional to label.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

<img width="1031" alt="Screen Shot 2023-03-22 at 9 15 10 AM" src="https://user-images.githubusercontent.com/12522275/226969329-77d9099f-70fe-4705-8055-66ea2595cd48.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
