### PR TITLE
Fix small icon-only padding and icon rendering

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -313,7 +313,7 @@ export const hpe = deepFreeze({
       background: { color: 'brand' },
       color: 'text-primary-button',
       font: { weight: 'bold' },
-      icon: Hpe,
+      icon: <Hpe />,
       reverse: true,
       extend: (props) => primaryBackground(props),
     },
@@ -323,7 +323,7 @@ export const hpe = deepFreeze({
       font: {
         weight: 'bold',
       },
-      icon: () => <Hpe color="brand" />,
+      icon: <Hpe color="brand" />,
       reverse: true,
     },
     default: {
@@ -456,7 +456,7 @@ export const hpe = deepFreeze({
           horizontal: '18px',
         },
         iconOnly: {
-          pad: '9px',
+          pad: '10px',
         },
         toolbar: {
           border: {
@@ -851,7 +851,7 @@ export const hpe = deepFreeze({
       container: {
         gap: 'xsmall',
       },
-      icon: () => <CircleAlert size="small" />,
+      icon: <CircleAlert size="small" />,
       size: 'xsmall',
       color: 'text',
       margin: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adjusts small icon-only padding to `10px` to ensure `36px` dimensions. Reverts changes to icon format from #342 which was causing error/not rendering icon.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

<img width="332" alt="Screen Shot 2023-03-23 at 9 18 33 AM" src="https://user-images.githubusercontent.com/12522275/227270892-c68f2557-5b5a-43f9-8c9d-3e33c3d6a301.png">
<img width="359" alt="Screen Shot 2023-03-23 at 9 18 12 AM" src="https://user-images.githubusercontent.com/12522275/227270896-4840e42b-570f-44b2-b30c-a32226d64b8f.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
