### PR TITLE
Update DataTable units to use text-weak

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -742,6 +742,9 @@ export const hpe = deepFreeze({
         },
       },
       pad: { horizontal: 'small', vertical: 'xsmall' },
+      units: {
+        color: 'text-weak',
+      },
     },
     icons: {
       ascending: () => <Ascending size="large" />,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates DataTable header units to use "text-weak" to meet accessibility contrast requirements.

#### What testing has been done on this PR?

Local in DS site.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #326 

#### Screenshots (if appropriate)
<img width="1110" alt="Screen Shot 2023-04-03 at 11 12 12 AM" src="https://user-images.githubusercontent.com/12522275/229592286-61c10c15-1761-4a30-8e5b-f10548dddb57.png">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
Updated DataTable units color to meet color contrast requirements.