### PR TITLE
fix template literal interpolations

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -613,15 +613,13 @@ export const hpe = deepFreeze({
       // HPE Design System guidance states that pad="none" should be applied on CheckBox
       // when its used outside of a FormField. We will apply this hover treatment in
       // those instances.
-      extend: ({ disabled, pad, theme }) => `
-      ${
-        !disabled &&
+      extend: ({ disabled, pad, theme }) => css`
+        ${!disabled &&
         pad === 'none' &&
         `border: 2px solid ${
           theme.global.colors['border-strong'][theme.dark ? 'dark' : 'light']
-        };`
-      }
-    `,
+        };`}
+      `,
     },
     color: 'background',
     border: {
@@ -671,7 +669,7 @@ export const hpe = deepFreeze({
     // HPE Design System guidance states that pad="none" should be applied on CheckBox
     // when its used outside of a FormField. We will apply this hover treatment in
     // those instances.
-    extend: ({ disabled, pad }) => `
+    extend: ({ disabled, pad }) => css`
     ${
       !disabled &&
       pad === 'none' &&


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

When upgrading to 5.0.1, GLCP reported an error in their Jest test suite: `undefined:1:1232: property missing ':'` related to a checkbox test.

https://github.com/styled-components/jest-styled-components/issues/97#issuecomment-364169127 pointed to https://styled-components.com/docs/api#css as the solution.

Most discussion points to the styles being rendered correctly in browsers, but throwing errors in certain Jest environments.

#### What testing has been done on this PR?

Built project locally and consumed in GLCP/frontend/ui Jest test suite.

#### Any background context you want to provide?

Reported by Annie.

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
