### PR TITLE
Changed release-gh-pages to use plain name

### DIFF
--- a/tools/release-gh-pages.js
+++ b/tools/release-gh-pages.js
@@ -17,13 +17,7 @@ if (process.env.CI) {
       .then(() =>
         fs.copy(
           `${localDist}/grommet-theme-hpe.min.js`,
-          `${localFolder}/grommet-theme-hpe-2.min.js`,
-        ),
-      )
-      .then(() =>
-        fs.copy(
-          `${localDist}/grommet-theme-hpe.json`,
-          `${localFolder}/grommet-theme-hpe-2.json`,
+          `${localFolder}/grommet-theme-hpe.min.js`,
         ),
       )
       .then(() => git(localFolder).add(['--all', '.']))


### PR DESCRIPTION
#### What does this PR do?

Changed release-gh-pages to use plain name

#### What testing has been done on this PR?

waiting for CircleCI

#### Any background context you want to provide?

The GitHub pages are used by grommet-designer and the "hpe" theme should be associated with the latest default path.

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

coordinated with grommet-designer

#### How should this PR be communicated in the release notes?

shouldn't be needed
