### PR TITLE
Abstract button.option and apply emptySearchMessage pad

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -55,6 +55,22 @@ const primaryHoverBackground = (props) =>
     ? `background-color: ${props.theme.global.colors.green.dark};`
     : '';
 
+// option button kind styles. abstracted so select.emptySearchMessage
+// can reference pad value
+const option = {
+  color: 'text',
+  border: {
+    radius: '0px',
+  },
+  pad: {
+    horizontal: '12px',
+    vertical: '6px',
+  },
+  font: {
+    weight: 500,
+  },
+};
+
 export const hpe = deepFreeze({
   defaultMode: 'light',
   global: {
@@ -363,19 +379,7 @@ export const hpe = deepFreeze({
         weight: 700,
       },
     },
-    option: {
-      color: 'text',
-      border: {
-        radius: '0px',
-      },
-      pad: {
-        horizontal: '12px',
-        vertical: '6px',
-      },
-      font: {
-        weight: 500,
-      },
-    },
+    option,
     active: {
       background: {
         color: 'background-contrast',
@@ -1403,6 +1407,11 @@ export const hpe = deepFreeze({
           cursor: default;
         }`}
       `,
+    },
+    emptySearchMessage: {
+      container: {
+        pad: option.pad,
+      },
     },
     icons: {
       color: 'text',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Add `select.emptySearchMessage` pad which references button.option.pad value.

Will require grommet patch release to see styling come through. Functionality added by: https://github.com/grommet/grommet/pull/6815

#### What testing has been done on this PR?
Tested in grommet storybook in PR linked above.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
