### PR TITLE
Update grommet peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/grommet/grommet-theme-hpe.git"
   },
   "peerDependencies": {
-    "grommet": "^2.32.0",
+    "grommet": "^2.32.2",
     "grommet-icons": "^4.10.0",
     "react": "^16.13.1 || ^17.0.1 || ^18.0.0",
     "styled-components": "^5.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates grommet peer dependency to latest patch release which supports `theme.search.emptySearchMessage`.

#### What testing has been done on this PR?
Tested locally in DS site and GLCP.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
