### PR TITLE
Adds xsmall breakpoint to pageheader

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1252,6 +1252,9 @@ export const hpe = deepFreeze({
     },
   },
   pageHeader: {
+    responsive: {
+      breakpoints: ['xsmall', 'small'],
+    },
     subtitle: {
       size: 'xlarge',
     },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Closes https://github.com/grommet/grommet-theme-hpe/issues/361

Adds 'xsmall' breakpoint to pageheader

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
