### PR TITLE
Fix build step and exports to allow npm install of branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "grommet-theme-hpe",
   "version": "5.0.3",
-  "main": "dist/index.js",
-  "module": "dist/es6/index.js",
-  "jsnext:main": "dist/es6/index.js",
+  "main": "index.js",
+  "module": "es6/index.js",
+  "jsnext:main": "es6/index.js",
   "sideEffects": false,
   "description": "Hewlett Packard Enterprise theme for grommet",
   "authors": [
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build && npm run jsonify",
-    "build": "webpack --mode production && cross-env babel ./src/js/ --out-dir ./dist --copy-files && cross-env BABEL_ENV=es6 babel ./src/js/ --out-dir ./dist/es6 --copy-files",
+    "build": "webpack --mode production && cross-env babel ./src/js/ --out-dir ./dist --copy-files && cp LICENSE package.json dist/ && cross-env BABEL_ENV=es6 babel ./src/js/ --out-dir ./dist/es6 --copy-files",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",
     "prettier": "pretty-quick --staged",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Makes adjustments to build step and entry points in package.json so that npm install of stable branch will work.

Issues were:
1. `stable` branch didn't have a package.json but needs one for npm to know where to look (copies this over similar to how grommet stable branch works, grommet-exp, etc.)
2. adjusts the `main`, `module`, and `jsnext:main` paths to reflect the file structure (aligns with grommet setup). There is no `dist` folder in stable branch, instead point directly to the `index.js` files.

#### What testing has been done on this PR?

Will be able to text this locally with npm once merged.

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #99 
Closes #78 

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
