### PR TITLE
Revert package.json changes to fix npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "grommet-theme-hpe",
   "version": "5.1.0",
-  "main": "index.js",
-  "module": "es6/index.js",
-  "jsnext:main": "es6/index.js",
+  "main": "dist/index.js",
+  "module": "dist/es6/index.js",
+  "jsnext:main": "dist/es6/index.js",
   "sideEffects": false,
   "description": "Hewlett Packard Enterprise theme for grommet",
   "authors": [
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build && npm run jsonify",
-    "build": "webpack --mode production && cross-env babel ./src/js/ --out-dir ./dist --copy-files && cp LICENSE package.json dist/ && cross-env BABEL_ENV=es6 babel ./src/js/ --out-dir ./dist/es6 --copy-files",
+    "build": "webpack --mode production && cross-env babel ./src/js/ --out-dir ./dist --copy-files && cross-env BABEL_ENV=es6 babel ./src/js/ --out-dir ./dist/es6 --copy-files",
     "lint": "eslint src",
     "lint-fix": "eslint src --fix",
     "prettier": "pretty-quick --staged",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Reverts https://github.com/grommet/grommet-theme-hpe/pull/368/files which caused incorrect entry point for published npm package which has a different directory structure than our `stable` branches.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
