### PR TITLE
Keep weight 400 for hpePop

### DIFF
--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -35,6 +35,9 @@ export const hpePop = deepMerge(hpe, {
     weight: 400,
     level: {
       1: {
+        font: {
+          weight: 400,
+        },
         small: {
           size: '48px',
           height: '48px',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

hpePop heading weight should not be altered by 5.1.0 product theme.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
