### PR TITLE
Fix h4 heading weight

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1041,7 +1041,9 @@ export const hpe = deepFreeze({
       let fontWeight = '';
       if (level === 3 && size === 'small') {
         fontWeight = 'font-weight: 600;';
-      } else if (level === 4 && ['small', 'medium'].includes(size)) {
+        // undefined necessary so an h4 without size prop explicitly defined
+        // still renders as weight 600
+      } else if (level === 4 && ['small', 'medium', undefined].includes(size)) {
         fontWeight = 'font-weight: 600;';
       } else if (level === 5 && size === 'xlarge') {
         fontWeight = 'font-weight: 500;';


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Ensures h4 renders at 600 at medium size. When `size` prop is not explicitly defined on Heading level 4, it should still render at 600 weight.

The logic and current Figma styles confirm that h4 at medium  should be weight 600.

#### What testing has been done on this PR?
Tested locally in Design System site.

First h4 has `size="medium"`, Second h4 does not have size prop. Both render as weight 600.

<img width="284" alt="Screen Shot 2024-01-18 at 10 25 49 AM" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/84bd4344-f886-4886-b1e4-ebf22e8f1510">

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
