### PR TITLE
Notification -- Incorporate staged changes from documentation site

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1135,11 +1135,15 @@ export const hpe = deepFreeze({
     actions: {
       color: { light: 'text', dark: 'text-strong' },
     },
-    direction: 'row',
+    close: {
+      icon: Close,
+    },
     container: {
       round: 'xsmall',
     },
+    direction: 'column',
     global: {
+      direction: 'row',
       container: {
         round: 'none',
       },
@@ -1205,9 +1209,6 @@ export const hpe = deepFreeze({
       toast: {
         background: 'background-front',
       },
-    },
-    toast: {
-      direction: 'column',
     },
   },
   page: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR:
- Adjusts the direction of default (inline) notifications to `column`.
   - Remove of `toast` specific direction since `column` is now the base direction.
   - Adding `global` specific direction to retain existing `row` orientation.
 - Updates Notification to use `Close` icon instead of `FormClose`.

#### What testing has been done on this PR?
Local in Design System site.

<img width="451" alt="Screen Shot 2024-01-23 at 10 33 51 AM" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/aa4ebeca-4aa9-4aca-8106-31676a2e0169">

<img width="1083" alt="Screen Shot 2024-01-23 at 10 41 36 AM" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/59c8c588-ba81-46d3-8ba8-b2e5d5745f35">

<img width="1169" alt="Screen Shot 2024-01-23 at 10 32 40 AM" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/655dfac3-c6e3-4bdf-b805-62ce473faa3c">

<img width="1680" alt="Screen Shot 2024-01-23 at 10 32 08 AM" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/2d1094c8-786e-4826-b0e3-7c3ee46fccca">

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/hpe-design-system/issues/3627

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
