### PR TITLE
Fix Table pad

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -748,7 +748,6 @@ export const hpe = deepFreeze({
           color: 'background-contrast',
         },
       },
-      pad: { horizontal: 'small', vertical: 'xsmall' },
       units: {
         color: 'text-weak',
       },
@@ -1514,8 +1513,6 @@ export const hpe = deepFreeze({
           justify-content: center;
         }
       `,
-      // space for focus indicator on sortable columns
-      pad: { left: 'none', vertical: 'none', right: 'xxsmall' },
     },
     body: {
       extend: ({ theme }) =>


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes Table pad by removing custom pad. Instead, we can rely directly on what comes by default from grommet since it aligns with our theming. This will feed from Table --> DataTable as well so they're in sync.

The note about needing the padding for when sortable no longer appears to be necessary (see screenshots below).

#### What testing has been done on this PR?

Local in design system site:

<img width="357" alt="Captura de Pantalla 2024-03-20 a la(s) 10 01 15 a m" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/e51aa3c2-05e8-4c55-a57b-67415365f08a">

Showing focus/hover state in DataTable
<img width="379" alt="Captura de Pantalla 2024-03-20 a la(s) 9 59 49 a m" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/77ec9b0e-e278-42c3-aae9-8fdfe3693255">

#### Any background context you want to provide?

#### What are the relevant issues?

Slack thread: https://hpe.slack.com/archives/C04LMJWQT/p1710861256038419

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible.

#### How should this PR be communicated in the release notes?
