### PR TITLE
Fix hover toggle

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -617,9 +617,10 @@ export const hpe = deepFreeze({
       // HPE Design System guidance states that pad="none" should be applied on CheckBox
       // when its used outside of a FormField. We will apply this hover treatment in
       // those instances.
-      extend: ({ disabled, pad, theme }) => css`
+      extend: ({ disabled, pad, theme, toggle }) => css`
         ${!disabled &&
         pad === 'none' &&
+        !toggle &&
         `border: 2px solid ${
           theme.global.colors['border-strong'][theme.dark ? 'dark' : 'light']
         };`}


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

When toggle is outside of formfield, the hover state was causing the knob to shift down. This aligns with Figma by not adjusting the toggle border width on hover.

#### What testing has been done on this PR?
Locally.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

BEFORE

https://github.com/grommet/grommet-theme-hpe/assets/12522275/3ce0ec35-3c26-4716-9e33-cf6bee7d49ee

AFTER

https://github.com/grommet/grommet-theme-hpe/assets/12522275/30cf498e-bd4b-4ddd-8237-bf0820f29dd9


#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
