### PR TITLE
Add ToggleGroup styles

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1639,6 +1639,20 @@ export const hpe = deepFreeze({
       color: 'brand',
     },
   },
+  toggleGroup: {
+    button: {
+      pad: {
+        vertical: 'xsmall',
+        horizontal: 'small',
+      },
+      iconOnly: {
+        pad: {
+          vertical: '9px',
+          horizontal: '9px',
+        },
+      },
+    },
+  },
   // Theme-Designer only parameters
   name: 'HPE 1',
   rounding: 4,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds ToggleGroup button styling to align to toolbar buttons.

#### What testing has been done on this PR?
Local in Design System site.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet-theme-hpe/issues/391

#### Screenshots (if appropriate)
<img width="365" alt="Screen Shot 2024-04-22 at 11 05 23 AM" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/1df90197-18e8-4cd1-902e-0dff1ef68671">
<img width="476" alt="Screen Shot 2024-04-22 at 11 05 13 AM" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/930735a5-8d05-43d3-b35e-3397e7364d55">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible.

#### How should this PR be communicated in the release notes?
Added ToggleGroup styles.