### PR TITLE
Fix list.item.pinned.icon.pad to align with button pad

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -71,6 +71,9 @@ const option = {
   },
 };
 
+// abstracted so button and pinned list icon can reference
+const mediumIconOnlyPad = '9px';
+
 export const hpe = deepFreeze({
   defaultMode: 'light',
   global: {
@@ -485,7 +488,7 @@ export const hpe = deepFreeze({
           horizontal: '18px',
         },
         iconOnly: {
-          pad: '9px',
+          pad: mediumIconOnlyPad,
         },
         toolbar: {
           border: {
@@ -1088,6 +1091,11 @@ export const hpe = deepFreeze({
   list: {
     item: {
       border: undefined,
+      pinned: {
+        icon: {
+          pad: mediumIconOnlyPad,
+        },
+      },
     },
   },
   maskedInput: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Abstract medium button iconOnly pad so that list.item.pinned.icon.pad can always be in sync.

#### What testing has been done on this PR?
Tested local in Design System site:

<img width="779" alt="Screen Shot 2024-04-23 at 2 56 57 PM" src="https://github.com/grommet/grommet-theme-hpe/assets/12522275/202a3f0f-e03b-40b5-af99-18c1948e1f97">

#### Any background context you want to provide?

#### What are the relevant issues?
Related to https://github.com/grommet/grommet/pull/7204

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Fix, the current misalignment is not as desired

#### How should this PR be communicated in the release notes?
