### PR TITLE
Add `background-selected-subtle` and `background-selected-subtle-hover`

### DIFF
--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -28,6 +28,14 @@ export const colors = {
     light: '#0000000A',
   },
   'background-layer-overlay': '#00000080',
+  'background-selected-subtle': {
+    light: '#CBFAEB',
+    dark: '#093A2F',
+  },
+  'background-selected-subtle-hover': {
+    light: '#AEF6DF',
+    dark: '#074B3B',
+  },
   icon: 'text',
   text: {
     dark: '#FFFFFF',

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -409,10 +409,10 @@ export const hpe = deepFreeze({
     },
     selected: {
       option: {
-        background: 'selected-background',
-        color: 'selected-text',
+        background: 'background-selected-subtle',
+        color: 'text-strong',
         font: {
-          weight: 700,
+          weight: 500,
         },
       },
     },
@@ -534,7 +534,7 @@ export const hpe = deepFreeze({
         },
       },
     },
-    extend: ({ hasIcon, hasLabel, sizeProp }) => {
+    extend: ({ hasIcon, hasLabel, kind, sizeProp, selected, theme }) => {
       // necessary so primary label is accessible on HPE green background
       const fontSize = '19px';
       const lineHeight = '24px';
@@ -544,6 +544,27 @@ export const hpe = deepFreeze({
         style += `font-size: ${fontSize};
         line-height: ${lineHeight};`;
       }
+      // manual solution for selected + hover state
+      // https://github.com/grommet/grommet-theme-hpe/issues/390#issuecomment-2083875178
+      style += `
+          &:hover {
+           background: ${
+             kind === 'option' && selected
+               ? theme.global.colors['background-selected-subtle-hover'][
+                   theme.dark ? 'dark' : 'light'
+                 ]
+               : ''
+           };
+           color: ${
+             kind === 'option' && selected
+               ? theme.global.colors[theme.button.selected.option.color][
+                   theme.dark ? 'dark' : 'light'
+                 ]
+               : ''
+           };
+          }
+        `;
+
       return style;
     },
   },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds background for select and select hover to allow for easier color contrast accessibility in Select component.

#### What testing has been done on this PR?
on the site 
#### Any background context you want to provide?
https://github.com/grommet/grommet-theme-hpe/issues/390
#### What are the relevant issues?
https://github.com/grommet/grommet-theme-hpe/issues/390
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
change 
#### How should this PR be communicated in the release notes?
