### PR TITLE
add icon color brand for anchor icon

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -267,6 +267,9 @@ export const hpe = deepFreeze({
     textDecoration: 'underline',
     fontWeight: 500,
     gap: 'xsmall',
+    icon: {
+      color: 'brand',
+    },
     hover: {
       textDecoration: 'underline',
     },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
adds `brand` for the icon color in Anchor
#### What testing has been done on this PR?
locally
#### Any background context you want to provide?
Add icon color brand with new Grommet support
#### What are the relevant issues?
for hpe theme release 
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
