### PR TITLE
change text color to pass accessibility

### DIFF
--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -35,7 +35,7 @@ export const colors = {
   },
   'text-strong': {
     dark: '#FFFFFF',
-    light: '#333333',
+    light: '#2e2e2e',
   },
   'text-weak': {
     dark: '#FFFFFF80', // 50%

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -35,7 +35,7 @@ export const colors = {
   },
   'text-strong': {
     dark: '#FFFFFF',
-    light: '#2e2e2e',
+    light: '#2E2E2E',
   },
   'text-weak': {
     dark: '#FFFFFF80', // 50%


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
changes text color slightly in order to pass accessibility for our light colors 
#### What testing has been done on this PR?
locally on DS site
#### Any background context you want to provide?
<img width="849" alt="Screenshot 2024-09-13 at 11 01 52 AM" src="https://github.com/user-attachments/assets/2dfad4aa-b169-45e7-9994-31aebfa1d81e">

our text colors were not passing for accessibility 
#### What are the relevant issues?
closes #401 
#### Screenshots (if appropriate)

with new color 
<img width="94" alt="Screenshot 2024-09-13 at 11 02 54 AM" src="https://github.com/user-attachments/assets/8501cadf-0a66-4ad1-a7a1-db828303721e">

<img width="767" alt="Screenshot 2024-09-13 at 11 02 31 AM" src="https://github.com/user-attachments/assets/7d70973e-dbce-498e-90a7-caa221eb6e48">

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?

Fix text color contrast on background colors.