### PR TITLE
Change datatable icons

### DIFF
--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -35,7 +35,7 @@ export const colors = {
   },
   'text-strong': {
     dark: '#FFFFFF',
-    light: '#333333',
+    light: '#2e2e2e',
   },
   'text-weak': {
     dark: '#FFFFFF80', // 50%

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -35,7 +35,7 @@ export const colors = {
   },
   'text-strong': {
     dark: '#FFFFFF',
-    light: '#2e2e2e',
+    light: '#33333',
   },
   'text-weak': {
     dark: '#FFFFFF80', // 50%

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -35,7 +35,7 @@ export const colors = {
   },
   'text-strong': {
     dark: '#FFFFFF',
-    light: '#33333',
+    light: '#333333',
   },
   'text-weak': {
     dark: '#FFFFFF80', // 50%

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -759,9 +759,12 @@ export const hpe = deepFreeze({
         color: 'text-weak',
       },
     },
+   // Ascending order is represented by a descending icon. 
+   // Similarly, descending order is shown with an ascending icon, 
+   // both signifying the respective sorting actions in line with industry standard conventions.
     icons: {
-      ascending: () => <Ascending size="large" />,
-      descending: () => <Descending size="large" />,
+      ascending: () => <Descending size="large" />,
+      descending: () => <Ascending size="large" />,
       contract: () => <Up height="medium" />,
       expand: () => <Down height="medium" />,
       sortable: () => <Unsorted size="large" />,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR changes the icons that are being used for the ascending and descending 
#### What testing has been done on this PR?
on DS site 
#### Any background context you want to provide?
These icons differ from industry standard direction (Material, Polaris, Carbon) and the general Grommet theme. We do not have strong rationale to differ, so we should swap these.
#### What are the relevant issues?
closes #403 
#### Screenshots (if appropriate)
with new changes:

https://github.com/user-attachments/assets/a1bd5997-c3a8-4923-9655-a2989a8f4d91


#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
yes