### PR TITLE
change icon for close in tag

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1555,6 +1555,9 @@ export const hpe = deepFreeze({
     },
   },
   tag: {
+    icons:{
+      remove: Close,
+    },
     pad: {
       horizontal: 'small',
       vertical: '5px', // 5px pad + 1px border = 6px 'xsmall'


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
changes the icon for remove in Tag
#### What testing has been done on this PR?
locally 
#### Any background context you want to provide?
we dont use formClose icons anymore
#### What are the relevant issues?
needed for Tag 
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
yes