### PR TITLE
Apply updated clear selection styles

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1423,26 +1423,15 @@ export const hpe = deepFreeze({
           horizontal: '12px',
           vertical: '6px',
         },
+        hover: {
+          background: 'background-contrast',
+        },
       },
       text: {
         color: 'text-strong',
+        size: '19px', // align to button font size
         weight: 600,
       },
-    },
-    container: {
-      // align font size with buttons
-      extend: ({ theme }) => `
-      & button[aria-label*="Clear selection"] {
-        font-size: 19px;
-      }
-      & button[aria-label*="Clear selection"]:hover {
-        background: ${
-          theme.global.colors['background-contrast'][
-            theme.dark ? 'dark' : 'light'
-          ]
-        };
-      }
-    `,
     },
     control: {
       extend: ({ disabled }) => css`

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1416,6 +1416,34 @@ export const hpe = deepFreeze({
     },
   },
   select: {
+    clear: {
+      container: {
+        background: undefined,
+        pad: {
+          horizontal: '12px',
+          vertical: '6px',
+        },
+      },
+      text: {
+        color: 'text-strong',
+        weight: 600,
+      },
+    },
+    container: {
+      // align font size with buttons
+      extend: ({ theme }) => `
+      & button[aria-label*="Clear selection"] {
+        font-size: 19px;
+      }
+      & button[aria-label*="Clear selection"]:hover {
+        background: ${
+          theme.global.colors['background-contrast'][
+            theme.dark ? 'dark' : 'light'
+          ]
+        };
+      }
+    `,
+    },
     control: {
       extend: ({ disabled }) => css`
         ${disabled &&


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Updates clear selection styles based on https://github.com/grommet/grommet/pull/7397.

The `text.size` will be able to be removed in the theme update, but this is to align with current button font sizing.

#### What testing has been done on this PR?

https://github.com/grommet/hpe-design-system/pull/4207

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #410 

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
Fixed color contrast on "Clear selection" button in Select.