### PR TITLE
Fix ThumbsRating and StarRating in FormField

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1582,6 +1582,30 @@ const buildTheme = (tokens, flags) => {
             }; `,
         },
       },
+      thumbsRating: {
+        container: {
+          extend: ({ error }) =>
+            `border-color: ${
+              error
+                ? components.hpe.formField.default.input.group.container.error
+                    .rest.borderColor
+                : components.hpe.formField.default.input.group.container.rest
+                    .borderColor
+            }; `,
+        },
+      },
+      starRating: {
+        container: {
+          extend: ({ error }) =>
+            `border-color: ${
+              error
+                ? components.hpe.formField.default.input.group.container.error
+                    .rest.borderColor
+                : components.hpe.formField.default.input.group.container.rest
+                    .borderColor
+            }; `,
+        },
+      },
       disabled: {
         background:
           components.hpe.formField.default.input.group.container.disabled.rest


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes styling of StarRating and ThumbsRating in FormField to behave like other grouped inputs (no border color in rest state).

#### What testing has been done on this PR?

Locally in sandbox/grommet-app

BEFORE

<img width="173" alt="Screenshot 2025-02-05 at 6 19 58 PM" src="https://github.com/user-attachments/assets/912080a2-98b1-4d40-acc6-761baf93868a" />

<img width="214" alt="Screenshot 2025-02-05 at 6 20 54 PM" src="https://github.com/user-attachments/assets/bb309f0e-ce6a-4198-bfde-bfb89ed4a857" />

AFTER

<img width="177" alt="Screenshot 2025-02-05 at 6 21 30 PM" src="https://github.com/user-attachments/assets/3dc8c543-face-44fa-9d61-c7993775ea82" />

<img width="208" alt="Screenshot 2025-02-05 at 6 21 19 PM" src="https://github.com/user-attachments/assets/ec50ffcb-83c2-4a48-bd07-b50f6e0f47c2" />

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
