### PR TITLE
Added Pagination selected.hover styling

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2200,6 +2200,13 @@ const buildTheme = (tokens, flags) => {
           font: {
             weight: components.hpe.button.default.hover.fontWeight,
           },
+          active: {
+            background: components.hpe.button.default.selected.hover.background,
+            color: components.hpe.button.default.selected.hover.textColor,
+            font: {
+              weight: components.hpe.button.default.selected.hover.fontWeight,
+            },
+          },
         },
         disabled: {
           background: components.hpe.button.default.disabled.rest.background,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds missing Pagination `selected.hover` styling.

#### What testing has been done on this PR?

Locally in sandbox/grommet-app

BEFORE

https://github.com/user-attachments/assets/805162ba-06da-4a21-a961-4522c0266683

AFTER

https://github.com/user-attachments/assets/08571993-d4d4-48a2-83b5-a5ad2ff6efca


#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
