### PR TITLE
Fix states for select.option

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -799,7 +799,6 @@ const buildTheme = (tokens, flags) => {
         extend: ({ kind, theme }) =>
           kind === 'option' &&
           `
-          background: transparent;
           &[aria-selected="true"] { background: ${getThemeColor(
             components.hpe.select.default.option.selected.rest.background,
             theme,

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -448,21 +448,6 @@ const buildTheme = (tokens, flags) => {
               components.hpe.button?.[kind]?.[adjustedState]?.hover?.fontWeight,
           },
         };
-      } else if (kind === 'option') {
-        if (state === 'active') adjustedState = 'selected';
-        buttonStatesTheme[state][kind] = {
-          background: {
-            color:
-              components.hpe.select.default.option?.[adjustedState].rest
-                .background,
-          },
-          border: {
-            color:
-              components.hpe.select.default.option?.[adjustedState].borderColor,
-          },
-          color:
-            components.hpe.select.default.option?.[adjustedState].textColor,
-        };
       } else if (state === 'disabled') {
         buttonStatesTheme[state][kind] = {
           background: {
@@ -808,10 +793,34 @@ const buildTheme = (tokens, flags) => {
       },
       ...buttonKindTheme,
       option,
-      active: buttonStatesTheme.active,
+      active: {
+        ...buttonStatesTheme.active,
+        // applies when option is in focus
+        extend: ({ kind, theme }) =>
+          kind === 'option' &&
+          `
+          background: transparent;
+          &[aria-selected="true"] { background: ${getThemeColor(
+            components.hpe.select.default.option.selected.rest.background,
+            theme,
+          )}; }`,
+      },
       disabled: {
         opacity: 1,
         ...buttonStatesTheme.disabled,
+        option: {
+          background:
+            components.hpe.select.default.option.disabled.rest.background,
+          border: {
+            color:
+              components.hpe.select.default.option.disabled.rest.borderColor,
+          },
+          color: components.hpe.select.default.option.disabled.rest.textColor,
+          font: {
+            weight:
+              components.hpe.select.default.option.disabled.rest.fontWeight,
+          },
+        },
       },
       selected: {
         option: {
@@ -821,12 +830,12 @@ const buildTheme = (tokens, flags) => {
             color:
               components.hpe.select.default.option.selected.rest.borderColor,
           },
-          color: components.hpe.select.default.option.selected.textColor,
+          color: components.hpe.select.default.option.selected.rest.textColor,
           font: {
             weight:
               components.hpe.select.default.option.selected.rest.fontWeight,
           },
-          extend: ({ theme }) =>
+          extend: ({ theme, disabled }) =>
             `
             position: relative;
             &::before {
@@ -850,7 +859,9 @@ const buildTheme = (tokens, flags) => {
               };
               left: ${components.hpe.select.default.medium.option.marker.left};
               background: ${getThemeColor(
-                components.hpe.select.default.option.marker.rest.background,
+                !disabled
+                  ? components.hpe.select.default.option.marker.rest.background
+                  : 'border-disabled',
                 theme,
               )};
             }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

"option" styles are handled as separate logic to buttonKindTheme and buttonStates theme. This PR:
- Removes unused block of code in those functions that checked for "if kind === 'option'" even though the kind array we're mapping through doesn't use "option"
- Adds appropriate missing states for option styles: disabled, active (which applies when "option" has keyboard focus)
- Fixes incorrect reference to textColor token

#### What testing has been done on this PR?

Locally in sandbox/grommet-app

BEFORE

https://github.com/user-attachments/assets/2971127b-671a-4587-87ca-14b4e24aa787

AFTER


https://github.com/user-attachments/assets/8565a6d4-1fe8-451a-9323-cb7ec5da5f3d




#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
