### PR TITLE
Fix styling of TextInput and MaskedInput suggestions

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -671,6 +671,15 @@ const buildTheme = (tokens, flags) => {
          * at a z-index of 101. This adjustment brings Drop in alignment with Layer
          * which needs an elevated z-index to sit atop the Global header. */
         zIndex: components.hpe.drop.default.zIndex,
+        extend: () => `
+          [class*=MaskedInput__ContainerBox] {
+            padding-block: ${components.hpe.select.default.medium.drop.paddingY};
+            padding-inline: ${components.hpe.select.default.medium.drop.paddingX};
+            gap: ${components.hpe.select.default.medium.drop.gapY};
+            display: flex;
+            flex-direction: column;
+          }
+        `,
       },
       elevation: {
         // Elevation values were derived from this Figma file.
@@ -2699,6 +2708,21 @@ const buildTheme = (tokens, flags) => {
             stroke: ${
               theme.global.colors['icon-strong'][theme.dark ? 'dark' : 'light']
             };
+          }
+        `,
+      },
+      suggestions: {
+        extend: ({ theme }) => `
+          padding-block: ${components.hpe.select.default.medium.drop.paddingY};
+          padding-inline: ${components.hpe.select.default.medium.drop.paddingX};
+          gap: ${components.hpe.select.default.medium.drop.gapY};
+          display: flex;
+          flex-direction: column;
+          [role="option"]:hover {
+            background: ${getThemeColor(
+              components.hpe.select.default.option.hover.background,
+              theme,
+            )};
           }
         `,
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes styling of TextInput and MaskedInput suggestions to align with new select.option styles.

MaskedInput doesn't have a drop specific extend, so needed to use the global extend for now. Will file grommet tickets for all the areas we're using extend.

#### What testing has been done on this PR?

Locally in sandbox/grommet-app

BEFORE

https://github.com/user-attachments/assets/a5891db1-c962-4d30-b898-09bdc56f8d1c


https://github.com/user-attachments/assets/72dd9c87-72f3-408f-bde9-fc3a986e8c0d




AFTER

https://github.com/user-attachments/assets/dd2cd3b8-2483-4915-bb6f-914b951498be


https://github.com/user-attachments/assets/9852097c-3a39-4e2d-93bc-1e3374e8ce7c



#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
