### PR TITLE
Fix checkbox disabled and selected states

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1074,14 +1074,18 @@ const buildTheme = (tokens, flags) => {
           } else if (checked) {
             if (toggle) {
               borderColor = getThemeColor(
-                components.hpe.switch.default.control.track.selected.hover
-                  .borderColor,
+                'transparent',
+                // incorrect token value to be updated in next minor hpe-design-tokens release
+                // components.hpe.switch.default.control.track.selected.hover
+                //   .borderColor,
                 theme,
               );
             } else {
               borderColor = getThemeColor(
-                components.hpe.checkbox.default.control.selected.hover
-                  .borderColor,
+                'transparent',
+                // incorrect token value to be updated in next minor hpe-design-tokens release
+                // components.hpe.checkbox.default.control.selected.hover
+                //   .borderColor,
                 theme,
               );
             }
@@ -1121,7 +1125,9 @@ const buildTheme = (tokens, flags) => {
               theme,
             );
             borderColor = getThemeColor(
-              components.hpe.checkbox.default.control.selected.rest.borderColor,
+              'transparent',
+              // incorrect token value to be updated in next minor hpe-design-tokens release
+              // components.hpe.checkbox.default.control.selected.rest.borderColor,
               theme,
             );
           }
@@ -1147,14 +1153,15 @@ const buildTheme = (tokens, flags) => {
             &:hover {
               ${!disabled ? `background: ${hoverBackground};` : ''}
             }
-            ${(checked || indeterminate) && 'border: none;'}
           `;
         },
       },
       icon: {
-        extend: ({ theme }) => `stroke-width: 2px;
+        extend: ({ theme, disabled }) => `stroke-width: 2px;
         stroke: ${getThemeColor(
-          components.hpe.checkbox.default.control.selected.rest.iconColor,
+          disabled
+            ? components.hpe.checkbox.default.control.disabled.rest.iconColor
+            : components.hpe.checkbox.default.control.selected.rest.iconColor,
           theme,
         )}`,
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes selected + disabled checkbox state. In doing so, identified a place where we were setting the "checked" state of checkbox to border: none (carry over from old theme version). We needed to remove this in order for the selected+disabled checkbox state to come through properly. It identified that the token value for `checkbox.default.control.selected.rest` and `checkbox.default.control.selected.hover` is incorrect. Proposing that we do an override in grommet-theme-hpe for the desired behavior, then remove this override once we do a minor version of hpe-design-tokens with any other first round refined styling/feedback.

#### What testing has been done on this PR?

Locally in sandbox/grommet-app

BEFORE

<img width="146" alt="Screenshot 2025-02-05 at 7 19 02 PM" src="https://github.com/user-attachments/assets/e8d1fa53-b300-4a3c-8bc5-a3d6f85577ae" />

AFTER

<img width="151" alt="Screenshot 2025-02-05 at 7 18 28 PM" src="https://github.com/user-attachments/assets/4432f5c3-2d08-4f79-b1b0-8e30568b38ce" />



#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
