### PR TITLE
Add all states styling for CTA buttons

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -799,19 +799,24 @@ const buildTheme = (tokens, flags) => {
         ...buttonKindTheme.primary,
         icon: <Hpe />,
         reverse: true,
-        extend: '',
       },
       'cta-alternate': {
         ...buttonKindTheme.secondary,
-        icon: <Hpe color="icon-brand" />,
+        icon: <Hpe color="brand" />,
         reverse: true,
       },
       ...buttonKindTheme,
       option,
-      active: buttonStatesTheme.active,
+      active: {
+        ...buttonStatesTheme.active,
+        'cta-primary': buttonStatesTheme.active.primary,
+        'cta-alternate': buttonStatesTheme.active.secondary,
+      },
       disabled: {
         opacity: 1,
         ...buttonStatesTheme.disabled,
+        'cta-primary': buttonStatesTheme.disabled.primary,
+        'cta-alternate': buttonStatesTheme.disabled.secondary,
       },
       selected: {
         option: {
@@ -861,6 +866,11 @@ const buildTheme = (tokens, flags) => {
         'cta-primary': buttonStatesTheme.hover.primary,
         'cta-alternate': buttonStatesTheme.hover.secondary,
         ...buttonStatesTheme.hover,
+        active: {
+          ...buttonStatesTheme.hover.active,
+          'cta-primary': buttonStatesTheme.hover.active.primary,
+          'cta-alternate': buttonStatesTheme.hover.active.secondary,
+        },
         option: {
           background: components.hpe.select.default.option.hover.background,
           border: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Including all states styling for cta-primary and cta-alternate button kinds. While these kinds might be deprecated in the future, we are retaining them as part of grommet-theme-hpe for at least this major version since we had not previously marked them as deprecated.

#### What testing has been done on this PR?

Locally in sandbox/grommet-app

cta-alternate uses "secondary" button styling

<img width="339" alt="Screenshot 2025-02-05 at 7 33 12 PM" src="https://github.com/user-attachments/assets/64cd4644-ae5a-43d8-b83f-7dfde879f6c7" />

cta-primary uses "primary" button styling

<img width="328" alt="Screenshot 2025-02-05 at 7 33 47 PM" src="https://github.com/user-attachments/assets/235be11a-9466-496d-83bc-eaea66bb6cd7" />

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
