### PR TITLE
Only apply :hover when not disabled

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1470,7 +1470,7 @@ const buildTheme = (tokens, flags) => {
                 components.hpe.formField.default.medium.input.group.item
                   .paddingX
               };
-              &:hover {
+              &:hover:not([disabled]) {
                 background: ${getThemeColor(
                   components.hpe.formField.default.input.container.hover
                     .background,
@@ -2305,7 +2305,7 @@ const buildTheme = (tokens, flags) => {
               )};
             }
           }
-          &:has(input[checked]):hover {
+          &:has(input[checked]):hover:not([disabled]) {
               & div:has(> svg[aria-hidden="true"]) {
                 background: ${getThemeColor(
                   components.hpe.radioButton.default.control.selected.hover
@@ -2389,7 +2389,7 @@ const buildTheme = (tokens, flags) => {
         },
       },
       control: {
-        extend: ({ disabled, theme }) => css`
+        extend: ({ disabled }) => css`
           ${disabled &&
           `
           opacity: 0.3;
@@ -2406,12 +2406,6 @@ const buildTheme = (tokens, flags) => {
               border-radius: ${dimensions.edgeSize[
                 components.hpe.select.default.medium.option.borderRadius
               ] || components.hpe.select.default.medium.option.borderRadius};
-              &:hover {
-                background: ${getThemeColor(
-                  components.hpe.select.default.option.hover.backgroud,
-                  theme,
-                )};
-              }
             }
           }
         `,
@@ -2538,7 +2532,7 @@ const buildTheme = (tokens, flags) => {
         border: undefined,
         extend: ({ theme }) => `
           border-radius: ${theme.global.edgeSize.xsmall}; 
-          & button[aria-selected="true"]:hover > div {
+          & button[aria-selected="true"]:hover:not([disabled]) > div {
             background: ${getThemeColor(
               'background-selected-primary-strong-hover',
               theme,

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1515,7 +1515,7 @@ const buildTheme = (tokens, flags) => {
                       .borderRadius
                   ]
                 };
-                &:hover {
+                &:hover:not([disabled]) {
                   background: ${getThemeColor(
                     components.hpe.formField.default.input.group.item.hover
                       .background,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Only applies :hover styling in extend when item is not disabled. Adjusts appropriate instances and removes unnecessary block in select.control.extend.

#### What testing has been done on this PR?

Locally in sandbox/grommet-app.

BEFORE
<img width="141" alt="Screenshot 2025-02-05 at 7 49 11 PM" src="https://github.com/user-attachments/assets/7a3bcb74-292c-4dbc-b1c8-23e845c66510" />

AFTER

<img width="149" alt="Screenshot 2025-02-05 at 7 48 36 PM" src="https://github.com/user-attachments/assets/e64244f1-477f-4cd9-aeb4-a72366cee32a" />


https://github.com/user-attachments/assets/5d058966-a363-4554-87a6-ad7d5070ab5e


https://github.com/user-attachments/assets/d2687b86-bc8d-4383-ae43-14d69ecbb82d



#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
