### PR TITLE
Removes unneeded button.extend which caused issues for DateInput + readOnlyCopy

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -893,19 +893,6 @@ const buildTheme = (tokens, flags) => {
           },
         },
       },
-      extend: ({ sizeProp, hasIcon, hasLabel, kind, plain }) => {
-        let style = '';
-        const iconOnly = hasIcon && !hasLabel;
-        // kind and size specific icon-only padding
-        if (
-          !plain &&
-          iconOnly &&
-          components.hpe.button[kind]?.[sizeProp]?.iconOnly?.paddingY &&
-          components.hpe.button[kind]?.[sizeProp]?.iconOnly?.paddingX
-        )
-          style += `padding: ${components.hpe.button[kind][sizeProp].iconOnly.paddingY} ${components.hpe.button[kind][sizeProp].iconOnly.paddingX}`;
-        return style;
-      },
     },
     calendar: {
       day: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Removes an unneeded button.extend which was undesirably overriding the "readOnlyCopy" button padding. This block was added during initial QA (which was odd given it wasn't needed in past versions of the theme) -- the initial reason it was added may have been rooted in an incorrect token value which has now been resolved. Removing this block does not have any effect on icon-only sizes (see screenshots).

#### What testing has been done on this PR?

Locally in sandbox/grommet-app
<img width="318" alt="Screenshot 2025-02-05 at 8 19 52 PM" src="https://github.com/user-attachments/assets/cd31723a-9fb6-43d1-a684-7ce985ac67a3" />
<img width="256" alt="Screenshot 2025-02-05 at 8 19 48 PM" src="https://github.com/user-attachments/assets/9320bedc-cfdc-43bc-9518-fadaecb96b72" />
<img width="324" alt="Screenshot 2025-02-05 at 8 19 23 PM" src="https://github.com/user-attachments/assets/ac9e2f69-9957-4001-98a8-f065a511ca4a" />
<img width="334" alt="Screenshot 2025-02-05 at 8 19 19 PM" src="https://github.com/user-attachments/assets/6874b066-f6d8-4928-90f2-405bb63ab600" />
<img width="327" alt="Screenshot 2025-02-05 at 8 19 14 PM" src="https://github.com/user-attachments/assets/218c8ee3-0e39-4a9e-b01e-6b89ed7922b9" />
<img width="321" alt="Screenshot 2025-02-05 at 8 19 10 PM" src="https://github.com/user-attachments/assets/924a48b5-67b5-4d7f-bbb7-dc9e049c986d" />
<img width="331" alt="Screenshot 2025-02-05 at 8 19 05 PM" src="https://github.com/user-attachments/assets/28e294b5-2f72-49da-83df-c483def32501" />
<img width="327" alt="Screenshot 2025-02-05 at 8 18 57 PM" src="https://github.com/user-attachments/assets/02d5fc8a-7e6c-457f-937a-9a7466755927" />
<img width="326" alt="Screenshot 2025-02-05 at 8 18 52 PM" src="https://github.com/user-attachments/assets/3c400859-6e0f-40bf-bc46-71d7870b7072" />
<img width="327" alt="Screenshot 2025-02-05 at 8 18 47 PM" src="https://github.com/user-attachments/assets/8d9b0582-0e76-4e81-a6bd-9811d14b11ba" />
<img width="327" alt="Screenshot 2025-02-05 at 8 18 41 PM" src="https://github.com/user-attachments/assets/d26c99a7-fa0b-48c0-97f2-dbdb91cb8500" />
<img width="340" alt="Screenshot 2025-02-05 at 8 18 36 PM" src="https://github.com/user-attachments/assets/955a4a1a-7029-4645-88fd-edf0f921682c" />
<img width="329" alt="Screenshot 2025-02-05 at 8 18 30 PM" src="https://github.com/user-attachments/assets/7afebab3-a713-43d5-a211-f05bc648a66e" />
<img width="335" alt="Screenshot 2025-02-05 at 8 18 26 PM" src="https://github.com/user-attachments/assets/a8a655f3-7bc1-4b7f-a559-840bf0e297aa" />
<img width="321" alt="Screenshot 2025-02-05 at 8 18 22 PM" src="https://github.com/user-attachments/assets/80125b14-c020-4919-8220-bbedb2acd323" />
<img width="356" alt="Screenshot 2025-02-05 at 8 18 17 PM" src="https://github.com/user-attachments/assets/f1a0ef2d-9222-4760-b9fe-b8f7424e088b" />
<img width="323" alt="Screenshot 2025-02-05 at 8 18 12 PM" src="https://github.com/user-attachments/assets/ab4b8bdb-187d-425e-95a5-3e4ceb8ef0c0" />
<img width="322" alt="Screenshot 2025-02-05 at 8 18 08 PM" src="https://github.com/user-attachments/assets/0a40e7ed-4a27-4d55-a2d3-3574444b9a8c" />
<img width="332" alt="Screenshot 2025-02-05 at 8 18 00 PM" src="https://github.com/user-attachments/assets/fa30bd90-a805-4e27-a6e9-cfa6f7452988" />
<img width="323" alt="Screenshot 2025-02-05 at 8 17 55 PM" src="https://github.com/user-attachments/assets/e41a388a-b68b-448e-8aa9-0884216aefcf" />
<img width="315" alt="Screenshot 2025-02-05 at 8 17 50 PM" src="https://github.com/user-attachments/assets/7b0ee1ab-f05e-49a9-b276-2fc68c36c7ad" />
<img width="324" alt="Screenshot 2025-02-05 at 8 17 46 PM" src="https://github.com/user-attachments/assets/a899dec4-1010-43f1-8524-cf6aa1cce64a" />


#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
