### PR TITLE
Fix primitive color reference

### DIFF
--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -79,6 +79,10 @@ export const colors = {
     dark: dark.hpe.color.text.default,
     light: light.hpe.color.text.default,
   },
+  'text-xweak': {
+    dark: dark.hpe.color.text.weak,
+    light: light.hpe.color.text.weak,
+  },
   border: {
     dark: dark.hpe.color.border.default,
     light: light.hpe.color.border.default,

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -105,7 +105,7 @@ export const colors = {
     dark: dark.hpe.color.decorative.purple,
     light: light.hpe.color.decorative.purple,
   },
-  'purple!': primitives.hpe.base.color['purple-800'],
+  'purple!': '#7630EA',
   red: {
     dark: dark.hpe.color.decorative.red,
     light: light.hpe.color.decorative.red,
@@ -115,7 +115,7 @@ export const colors = {
     dark: dark.hpe.color.decorative.orange,
     light: light.hpe.color.decorative.orange,
   },
-  'orange!': primitives.hpe.base.color['orange-500'],
+  'orange!': '#FF8300',
   yellow: {
     dark: dark.hpe.color.decorative.yellow,
     light: light.hpe.color.decorative.yellow,

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -79,6 +79,7 @@ export const colors = {
     dark: dark.hpe.color.text.default,
     light: light.hpe.color.text.default,
   },
+  // deprecated, remove in next major version
   'text-xweak': {
     dark: dark.hpe.color.text.weak,
     light: light.hpe.color.text.weak,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

In hpe-design-tokens we're not representing these "!" colors because they may not carry through to next brand iteration, so we did not want to carry over any baggage. We then removed any unused primitive colors from hpe-design-tokens, these two primitive colors were not used elsewhere in the semantic set so they were removed. For backwards compatibility, hard coding the existing value.

All other "!" primitive colors still exist.

Also fixing one other missing color reference. We removed "text-xweak" from design tokens for accessibility, but since we never marked it as "deprecated" in any previous grommet-theme-hpe, we will point it to "text-weak" so there is a value. In future major version of tokens we'll remove.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
