### PR TITLE
Hard code rangeinput upper track

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { css } from 'styled-components';
 import {
-  primitives as localPrimitives,
   dark as localDark,
   light as localLight,
   dimension as localDimension,
@@ -152,7 +151,6 @@ const getTextSize = (size) => {
 
 const buildTheme = (tokens, flags) => {
   const {
-    primitives,
     light,
     dark,
     small,
@@ -2414,7 +2412,12 @@ const buildTheme = (tokens, flags) => {
           color: 'background-primary-strong',
         },
         upper: {
-          color: primitives.hpe.base.color['grey-500'],
+          // hard-coding opaque version of 'border-weak' due to unresolved grommet bug
+          // https://github.com/grommet/grommet/issues/6739
+          color: {
+            light: '#e0e0e0',
+            dark: '#616161',
+          },
         },
         extend: () => `border-radius: ${large.hpe.radius.full};`,
       },
@@ -2814,7 +2817,6 @@ const buildTheme = (tokens, flags) => {
 
 export const hpe = buildTheme(
   {
-    primitives: localPrimitives,
     light: localLight,
     dark: localDark,
     small: localSmall,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Hard-coding opaque color value for rangeinput upper track color as workaround for existing grommet bug.

#### What testing has been done on this PR?

<img width="159" alt="Screenshot 2025-02-06 at 9 59 27 AM" src="https://github.com/user-attachments/assets/e422c8d9-c7ff-46cc-81d6-29c40f18f5c9" />

<img width="154" alt="Screenshot 2025-02-06 at 9 59 19 AM" src="https://github.com/user-attachments/assets/a1416996-197e-4259-a93d-a5ab24d08766" />


#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
