### PR TITLE
Fix clear-selection focus style

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2430,9 +2430,6 @@ const buildTheme = (tokens, flags) => {
             horizontal: '12px',
             vertical: '6px',
           },
-          margin: {
-            horizontal: components.hpe.select.default.medium.drop.paddingX,
-          },
           hover: {
             background: 'background-hover',
           },
@@ -2442,6 +2439,29 @@ const buildTheme = (tokens, flags) => {
           color: components.hpe.button.default.rest.textColor,
           weight: components.hpe.button.default.rest.fontWeight,
         },
+      },
+      container: {
+        // Applying spacing on Select "Clear selection" button, then placing focus styles on the inner container div
+        extend: ({ theme }) =>
+          `
+          button[aria-label*="Or, press"] {
+            padding-block: ${
+              components.hpe.select.default.medium.drop.paddingY
+            };
+            padding-inline: ${
+              components.hpe.select.default.medium.drop.paddingX
+            };
+            &:focus {
+              background: transparent;
+              > div {
+                background: ${getThemeColor(
+                  components.hpe.button.default.hover.background,
+                  theme,
+                )};
+              }
+            }
+          }
+        `,
       },
       control: {
         extend: ({ disabled }) => css`

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2444,6 +2444,9 @@ const buildTheme = (tokens, flags) => {
         // Applying spacing on Select "Clear selection" button, then placing focus styles on the inner container div
         extend: ({ theme }) =>
           `
+          div:has(input[type="search"]) {
+            padding-bottom: 0;
+          }
           button[aria-label*="Or, press"] {
             padding-block: ${
               components.hpe.select.default.medium.drop.paddingY


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Fixes clear selection :focus styles to accommodate/align to the "padding" around options.

#### What testing has been done on this PR?

Locally in sandbox/grommet-app


https://github.com/user-attachments/assets/13e73282-8dea-43e4-9d3c-ff4547378a95


#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
