### PR TITLE
Provide helpful fallback for color prop buttons

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -54,7 +54,9 @@ const textSizes = [
 ];
 
 const getThemeColor = (color, theme) =>
-  theme.global.colors[color]?.[theme.dark ? 'dark' : 'light'] || color;
+  typeof theme.global.colors[color] === 'string'
+    ? theme.global.colors[color]
+    : theme.global.colors[color]?.[theme.dark ? 'dark' : 'light'] || color;
 
 const globalSizes = {
   borderSize: {
@@ -917,6 +919,19 @@ const buildTheme = (tokens, flags) => {
             },
           },
         },
+      },
+      extend: ({ colorValue, theme }) => {
+        let style = '';
+        if (colorValue) {
+          // color prop is not recommended to be used, but providing
+          // a better fallback behavior for hover styles to avoid
+          // "kind" hover background from applying
+          // https://github.com/grommet/grommet/issues/7504
+          style += `
+            &:hover { background: ${getThemeColor(colorValue, theme)}; }
+          `;
+        }
+        return style;
       },
     },
     calendar: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

While we don't recommend use of `color` for HPE Design System. This PR provides a helpful fallback for color button hover styles to help accommodate some existing awkward logic in "color" + "kind" theme in [grommet](https://github.com/grommet/grommet/issues/7504). We also audited COM/GLP and they did not have instances of "color" Buttons, so the frequency of these occurring is low.

Without this, the "kind" specific hover styling would come through so we are just retaining the "color" as background color for consistency. Ideally in the future, the grommet "color" logic could provide more granular control for this styling.

NOTE: The text color still does receive the "kind" specific styling, but trying to go any deeper into the extend to control text color would require too much knowledge/repitition of internal grommet logic re: text color on background colors. Therefore, Grommet should be enhanced instead.

#### What testing has been done on this PR?

Tested locally in sandbox/grommet-app

https://github.com/user-attachments/assets/2a06027a-0db9-4bd4-bcef-6d2e54a29c2e



#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
