### PR TITLE
Use weight medium from `list.primaryKey`

### DIFF
--- a/.changeset/cuddly-files-change.md
+++ b/.changeset/cuddly-files-change.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed `list.primaryKey` to use font-weight "medium" instead of "bold".

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1709,6 +1709,7 @@ const buildTheme = (tokens, flags) => {
           icon: { pad: mediumIconOnlyPad },
         },
       },
+      primaryKey: { weight: global.hpe.fontWeight.medium },
     },
     maskedInput: {
       container: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

To align with shift away from "bold", fixes List primary key styling to use "medium" weight instead of bold.

#### What testing has been done on this PR?
Tested locally in storybook

BEFORE
<img width="267" alt="Screenshot 2025-02-26 at 1 16 26 PM" src="https://github.com/user-attachments/assets/d8d58ddc-0cd7-4042-a302-555a8b89afd3" />


AFTER
<img width="273" alt="Screenshot 2025-02-26 at 1 13 32 PM" src="https://github.com/user-attachments/assets/44ee9b1f-e9ba-49a1-a0f6-513ecb7744a2" />

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #444 

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
