### PR TITLE
Fix disabled input styling

### DIFF
--- a/.changeset/sixty-oranges-play.md
+++ b/.changeset/sixty-oranges-play.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed bug where inputs outside of FormField were not receiving disabled styling.

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1342,12 +1342,6 @@ const buildTheme = (tokens, flags) => {
     formField: {
       extend: ({ theme }) =>
         `
-          input:disabled {
-            color: ${getThemeColor(
-              components.hpe.formField.default.value.disabled.rest.textColor,
-              theme,
-            )};
-          }
           [class*="ContentBox"] {
             label {
               padding-block: ${

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -527,7 +527,7 @@ const buildTheme = (tokens, flags) => {
           color:
             components.hpe.formField.default.input.container.rest.borderColor,
         },
-        disabled: { opacity: 1 },
+        disabled: { opacity: 0.3 },
       },
       input: {
         font: {
@@ -2094,6 +2094,15 @@ const buildTheme = (tokens, flags) => {
           color: { light: '#e0e0e0', dark: '#616161' },
         },
         extend: () => `border-radius: ${large.hpe.radius.full};`,
+      },
+      disabled: {
+        opacity: 1,
+        track: { color: 'background-disabled' },
+        thumb: {
+          // opaque version of background-front + background-disabled
+          // to avoid stacking transparencies
+          color: { light: 'rgb(245, 245, 245)', dark: 'rgb(44, 44, 44)' },
+        },
       },
     },
     select: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Our overall desire is to head towards using disabled colors rather than opacity to drive "disabled" state. However, grommet does not currently support robust enough theme styling to enable this consistently across components.

For now, we will revert back to the existing "disabled opacity" approach and incorporate the "disabled colors" approach in the next major release once grommet supports this capability via: https://github.com/grommet/grommet/issues/7529

For RangeInput, since there are stacked disabled elements, I had to hard-code an opaque version of background-front + background-disabled for the thumb.

#### What testing has been done on this PR?

Locally in storybook. See "Fixes audit" in this Figjam: https://www.figma.com/board/N4X94MLi7mupnYIAO1yuhz/v6.0.0-audit?node-id=18-12852&t=qsN2pOw5Es914xez-1

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #447 

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
