### PR TITLE
Remove overly generic extend selector in `table.body`

### DIFF
--- a/.changeset/rare-boats-taste.md
+++ b/.changeset/rare-boats-taste.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed incorrect override of Button hover styles when in table body cell.

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2296,18 +2296,6 @@ const buildTheme = (tokens, flags) => {
           side: 'bottom',
           color: components.hpe.dataCell.default.rest.borderColor,
         },
-        extend: ({ theme }) =>
-          `
-            &:hover {
-              button {
-                background: ${
-                  theme.global.colors['background-hover'][
-                    theme.dark ? 'dark' : 'light'
-                  ]
-                };
-              }
-            }
-          `,
       },
       row: { hover: { background: 'background-hover' } },
       footer: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

NOTE: For versioning, I'd argue this should be a "fix" rather than a "minor" bump. Feels more likely that a team might render a Button kind (non-plain) in a table cell than use this "plain" pattern. So this would fix incorrect styling, but I am open to reviewer feedback.

Removes overly generic/opinionated extend selector in table body extend.

[The original introduction of this style](https://github.com/grommet/hpe-design-system/pull/1089/commits/cc75ca9b2aa805cd403dfd00053c18356920716c#diff-413a4b94bc47b0c7dfac6fe49ff6d52911c1af858f97f7024220a941a2cf1c74) references "plain buttons plus theme styling". 

I believe this referred specifically to the pattern where you might render a "plain" Button (button with children) inside a DataTable cell as a means of navigation ([See this example](https://design-system.hpe.design/components/datatable?q=datata#selecting-multiple-records-and-batch-actions) and the "order name" column).

I think the theme is trying to be too "smart" here and should really leave it up to the caller via their custom render function to style things how they want. Also, I don't even think this is a pattern teams typically follow. Instead, they usually use an "Anchor" treatment for navigation.

This ensures table doesn't reach into its custom render children styling.

#### What testing has been done on this PR?

https://codesandbox.io/p/sandbox/datatable-hover-ts59vy?file=%2Fsrc%2FApp.js%3A18%2C18

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #449 

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
