### PR TITLE
Add disabled carousel icon color

### DIFF
--- a/.changeset/tender-rockets-do.md
+++ b/.changeset/tender-rockets-do.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed Carousel disabled icon color

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -976,6 +976,13 @@ const buildTheme = (tokens, flags) => {
       header: { pad: 'medium' },
       hover: { container: { elevation: 'medium' } },
     },
+    carousel: {
+      disabled: {
+        icons: {
+          color: 'icon-disabled',
+        },
+      },
+    },
     checkBox: {
       hover: {
         border: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds missing disabled carousel icon color.

#### What testing has been done on this PR?
Local in storybook

BEFORE
<img width="250" alt="Screenshot 2025-02-27 at 1 18 24 PM" src="https://github.com/user-attachments/assets/d7585b14-cd65-4422-9e1a-7b60071972f5" />

AFTER
<img width="296" alt="Screenshot 2025-02-27 at 1 15 58 PM" src="https://github.com/user-attachments/assets/05a3bc64-24c6-472d-8329-2d713f11cdbf" />

#### Any background context you want to provide?

#### What are the relevant issues?
Closes #450 

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
