### PR TITLE
Add "graph-7" to correspond with final dataVis-categorical step

### DIFF
--- a/.changeset/seven-bottles-fix.md
+++ b/.changeset/seven-bottles-fix.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": minor
+---
+
+- Added "graph-7" to provide full range of dataVis-categorical colors offered by hpe-design-tokens.

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -154,6 +154,10 @@ export const colors = {
     light: light.hpe.color.dataVis['categorical-70'],
     dark: dark.hpe.color.dataVis['categorical-70'],
   },
+  'graph-7': {
+    light: light.hpe.color.dataVis['categorical-80'],
+    dark: dark.hpe.color.dataVis['categorical-80'],
+  },
   'status-critical': {
     dark: dark.hpe.color.icon.critical,
     light: light.hpe.color.icon.critical,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

NOTE: Marking as draft for now in case any other "fixes" come in that we'd like to release prior to next minor version.

Adds graph-7 to pull in corresponding design token. We manually map dataVis-categorical colors to "graph" colors for grommet to know how to use smartly. v6.0.0 did most of this mapping but "graph-7" was not included.

#### What testing has been done on this PR?

Locally in storybook

```
<Meter
      type="pie"
      size="small"
      values={[
        { value: 20 },
        { value: 20 },
        { value: 10 },
        { value: 10 },
        { value: 10 },
        { value: 10 },
        { value: 10 },
        { value: 10 },
      ]}
    />
```

BEFORE (with 8 graph elements, it's circling back around to 
<img width="255" alt="Screenshot 2025-03-05 at 3 30 03 PM" src="https://github.com/user-attachments/assets/ef6b5964-0385-4cf6-ab72-6d1013d9f57b" />

AFTER
<img width="341" alt="Screenshot 2025-03-05 at 3 29 52 PM" src="https://github.com/user-attachments/assets/9379454b-7c56-4e57-a0d8-fb692b83eba0" />

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
