### PR TITLE
Ensure Drop box-shadow is always visible

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -643,7 +643,22 @@ const buildTheme = (tokens, flags) => {
          * at a z-index of 101. This adjustment brings Drop in alignment with Layer
          * which needs an elevated z-index to sit atop the Global header. */
         zIndex: components.hpe.drop.default.zIndex,
-        extend: () => `
+        // in storybook, a bug was noted where some global styling is overriding
+        // the drop box-shadow when the drop container receives focus onOpen
+        // this ensures the box-shadow remains visible.
+        // https://github.com/grommet/hpe-design-system/issues/4873
+        extend: (props) => `
+          &:focus:not(:focus-visible) {
+            ${
+              props.elevation
+                ? `box-shadow: ${
+                    props.theme.global.elevation[
+                      props.theme.dark ? 'dark' : 'light'
+                    ][props.elevation]
+                  };`
+                : ''
+            }
+          }
           [class*=MaskedInput__ContainerBox] {
             padding-block: ${components.hpe.select.default.medium.drop.paddingY};
             padding-inline: ${components.hpe.select.default.medium.drop.paddingX};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

[This ticket](https://github.com/grommet/hpe-design-system/issues/4873#issuecomment-2752661372) highlighted the fact that in storybook, sometimes the drop's box-shadow is being overridden by some global style (unrelated to styled-components/grommet). This is a defensive PR to ensure that box-shadow does not get overridden when the Drop container receives focus.

#### What testing has been done on this PR?
- Checked that this works with theme default drop elevation.
- Checked that this works with custom `dropProps` elevation.

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/4873

#### Screenshots (if appropriate)

https://github.com/user-attachments/assets/fa6124b6-b79e-4db2-a3ad-3e7a7a7138b2

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
