### PR TITLE
Add keyboard specific styles for TextInput and MaskedInput suggestions

### DIFF
--- a/.changeset/strong-tips-allow.md
+++ b/.changeset/strong-tips-allow.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed accessibility bug where TextInput and MaskedInput suggestions were not receiving sufficient visual styling to meet WCAG requirements.

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -765,14 +765,47 @@ const buildTheme = (tokens, flags) => {
         ...buttonStatesTheme.active,
         'cta-primary': buttonStatesTheme.active.primary,
         'cta-alternate': buttonStatesTheme.active.secondary,
-        // applies when option is in focus
-        extend: ({ kind, theme }) =>
-          kind === 'option' &&
-          `
-          &[aria-selected="true"] { background: ${getThemeColor(
-            components.hpe.select.default.option.selected.rest.background,
-            theme,
-          )}; }`,
+        extend: ({ kind, theme, keyboard }) => {
+          let style;
+          // applies when option is in focus
+          if (kind === 'option') {
+            style += `
+            &[aria-selected="true"] { background: ${getThemeColor(
+              components.hpe.select.default.option.selected.rest.background,
+              theme,
+            )}; }`;
+          }
+          // keyboard specific styling for TextInput and MaskedInput suggestions
+          if (keyboard) {
+            style += `
+    position: relative;
+            &::before {
+              display: block;
+              position: absolute;
+              content: '';
+              width: ${
+                components.hpe.select.default.medium.option.marker.width
+              };
+              border-top-left-radius: ${
+                components.hpe.select.default.medium.option.marker
+                  .borderTopLeftRadius
+              };
+              border-bottom-left-radius: ${
+                components.hpe.select.default.medium.option.marker
+                  .borderBottomLeftRadius
+              };
+              top: ${components.hpe.select.default.medium.option.marker.top};
+              bottom: ${
+                components.hpe.select.default.medium.option.marker.bottom
+              };
+              left: ${components.hpe.select.default.medium.option.marker.left};
+              background: ${getThemeColor('border-selected', theme)};
+            }
+      }
+    `;
+          }
+          return style;
+        },
       },
       disabled: {
         opacity: 1,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Enabled by https://github.com/grommet/grommet/pull/7576. Adds keyboard specific styles to TextInput and MaskedInput suggestions (which don't receive the global focus outline bc of combobox nature and therefore require an additional marker)

We can merge now (any team on latest upcoming Grommet release will inherit this fix) or wait until next major bump. My recommendation would be to merge now given it fixes an accessibility issue.

In this video, first using mouse and then using keyboard.

https://github.com/user-attachments/assets/1893d58d-dc52-44bb-a4d6-025feaa9d306

#### What testing has been done on this PR?

Locally in sample app.

#### Any background context you want to provide?

#### What are the relevant issues?
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
