### PR TITLE
Adjust `tip.content.margin` to xsmall

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2441,7 +2441,7 @@ const buildTheme = (tokens, flags) => {
       content: {
         background: 'background-floating',
         border: { color: 'border-weak' },
-        margin: 'xxsmall',
+        margin: 'xsmall',
         elevation: 'small',
         pad: { vertical: 'none', horizontal: 'small' },
         round: components.hpe.drop.default.borderRadius,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

With grommet v2.47.0, `tip.drop.margin` now overrides `global.drop.margin` (a fix to logic). The desired spacing between tip and trigger is 6px. This PR adjusts `tip.content.margin` to provide space and ensure mouse can move between trigger/tip.

Marking this as a draft to be part of the next major version, when we're able to bump the grommet peerDependency version. If we merge now, for teams on grommet <2.47.0, they will have a gap of 12px between trigger and tip, which is much too large.

#### What testing has been done on this PR?

Local in design system site.
<img width="202" alt="Screenshot 2025-05-07 at 10 12 07 AM" src="https://github.com/user-attachments/assets/48f9b070-92ac-469b-b884-0c0343b6ed44" />

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/hpe-design-system/issues/5144

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
