### PR TITLE
V2 alpha - Added marketing typography scale

### DIFF
--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -32,202 +32,194 @@ export const deepMerge = (target, ...sources) => {
 export const hpePop = deepMerge(hpe, {
   heading: {
     color: 'text-strong',
-    weight: 400,
+    weight: 500,
     level: {
       1: {
-        font: { weight: 400 },
         small: {
           size: '3rem', // 48px
           height: '3rem', // 48px
         },
         medium: {
-          size: '4.5rem', // 72px
-          height: '4.5rem', // 72px
+          size: '4.25rem', // 68px
+          height: '4.625rem', // 74px
         },
         large: {
+          size: '5.25rem', // 84px
+          height: '5.625rem', // 90px
+        },
+        xlarge: {  // Heading condensed
           size: '6rem', // 96px
           height: '6rem', // 96px
         },
-        xlarge: {
-          size: '7.5rem', // 120px
-          height: '7.5rem', // 120px
-        },
+        xxlarge: { // Heading large condensed
+          size: '7rem', // 112px
+          height: '7rem', // 112px
+        }
       },
       2: {
         small: {
           size: '2.25rem', // 36px
-          height: '2.25rem', // 36px
+          height: '2.625rem', // 42px
         },
         medium: {
-          size: '3rem', // 48px
-          height: '3rem', // 48px
+          size: '3.25rem', // 52px
+          height: '3.625rem', // 58px
         },
         large: {
-          size: '4.5rem', // 72px
-          height: '4.5rem', // 72px
+          size: '4.25rem', // 68px
+          height: '4.625rem', // 74px
         },
-        xlarge: {
+        xlarge: { // Heading condensed
+          size: '5.25rem', // 84px
+          height: '5.625rem', // 90px
+        },
+        xxlarge: { // Heading large condensed
           size: '6rem', // 96px
           height: '6rem', // 96px
-        },
+        }
       },
       3: {
         small: {
-          size: '1.5rem', // 24px
-          height: '1.5rem', // 24px
+   
         },
         medium: {
           size: '2.25rem', // 36px
-          height: '2.25rem', // 36px
+          height: '2.625rem', // 42px
         },
         large: {
-          size: '3rem', // 48px
-          height: '3rem', // 48px
+          size: '3.25rem', // 52px
+          height: '3.625rem', // 58px
         },
-        xlarge: {
-          size: '4.5rem', // 72px
-          height: '4.5rem', // 72px
+        xlarge: { // Heading condensed
+          size: '4.25rem', // 68px
+          height: '4.625rem', // 74px
         },
+        xxlarge: { // Heading large condensed
+          size: '5.25rem', // 84px
+          height: '5.625rem', // 90px
+        }
       },
       4: {
-        font: { weight: 500 },
         small: {
-          size: '1.125rem', // 18px
-          height: '1.125rem', // 18px
+          size: '1.125rem', // 20px
+          height: '1.125rem', // 26px
         },
         medium: {
-          size: '1.5rem', // 24px
-          height: '1.5rem', // 24px
+          size: '1.5rem', // 28px
+          height: '1.5rem', // 34px
         },
         large: {
           size: '2.25rem', // 36px
-          height: '2.25rem', // 36px
+          height: '2.625rem', // 42px
         },
         xlarge: {
-          size: '3rem', // 48px
-          height: '3rem', // 48px
-        },
+          size: '3.25rem', // 52px
+          height: '3.625rem', // 58px
+        }
       },
       5: {
-        font: { weight: 500 },
         small: {
           size: '1rem', // 16px
-          height: '1rem', // 16px
+          height: '1.375rem', // 22px
         },
         medium: {
-          size: '1.125rem', // 18px
-          height: '1.125rem', // 18px
+          size: '1.125rem', // 20px
+          height: '1.125rem', // 26px
         },
         large: {
-          size: '1.5rem', // 24px
-          height: '1.5rem', // 24px
+          size: '1.5rem', // 28px
+          height: '1.5rem', // 34px
         },
         xlarge: {
           size: '2.25rem', // 36px
-          height: '2.25rem', // 36px
+          height: '2.625rem', // 42px
         },
       },
       6: {
-        font: { weight: 500 },
         small: {
-          size: '0.875rem', // 14px
-          height: '0.875rem', // 14px
+          size: '1rem', // 16px
+          height: '1.375rem', // 22px
         },
         medium: {
           size: '1rem', // 16px
-          height: '1rem', // 16px
+          height: '1.375rem', // 22px
         },
         large: {
-          size: '1.125rem', // 18px
-          height: '1.125rem', // 18px
+          size: '1.125rem', // 20px
+          height: '1.125rem', // 26px
         },
         xlarge: {
-          size: '1.5rem', // 24px
-          height: '1.5rem', // 24px
+          size: '2.25rem', // 36px
+          height: '2.625rem', // 42px
         },
       },
     },
     extend: ({ level, size }) => {
-      let fontWeight = '';
-      if (level === 3 && size === 'small') {
-        fontWeight = 'font-weight: 500;';
-      } else if (level === 4 && ['large', 'xlarge'].includes(size)) {
-        fontWeight = 'font-weight: 400;';
-      } else if (level === 5 && size === 'xlarge') {
-        fontWeight = 'font-weight: 400;';
-      } else if (level === 6 && size === 'small') {
-        fontWeight = 'font-weight: 600;';
+      let font = '';
+      if ([1, 2, 3].includes(level) && ['xlarge', 'xxlarge'].includes(size)) {
+        font = 'font-weight: 700; font-family: GraphikXXCondensed;';
       }
-      return fontWeight;
+      return font;
     },
   },
   paragraph: {
-    small: {
-      size: '1rem', // 16px
+    xsmall: { // disclaimer
+      size: '0.875rem', // 14px
       height: '1.25rem', // 20px
     },
-    medium: {
-      size: '1.125rem', // 18px
-      height: '1.375rem', // 22px
+    small: { // small body
+      size: '1rem', // 16px
+      height: '1.5rem', // 24px
     },
-    large: {
-      size: '1.5rem', // 24px
+    medium: { // body
+      size: '1.25rem', // 20px
       height: '1.875rem', // 30px
     },
-    xlarge: {
+    large: { // large body
+      size: '1.75rem', // 28px
+      height: '2.375rem', // 38px
+    },
+    xlarge: { // small quote
       size: '2.25rem', // 36px
-      height: '2.625rem', // 42px
+      height: '2.875rem', // 46px
     },
-    xxlarge: {
-      size: '2.625rem', // 42px
-      height: '3rem', // 48px
+    xxlarge: { // quote
+      size: '2.75rem', // 44px
+      height: '3.375rem', // 54px
     },
-    extend: ({ size }) => {
-      if (['large', 'xlarge', 'xxlarge'].includes(size))
-        return 'font-weight: 300;';
-      return '';
+    xxxlarge: { // large quote
+      size: '3.25rem', // 52px
+      height: '3.875rem', // 62px
     },
   },
   text: {
-    xsmall: {
-      // weight needs to be modified at the size level
+    xsmall: { // disclaimer
       size: '0.875rem', // 14px
-      height: '1.125rem', // 18px
-    },
-    small: {
-      // weight needs to be modified at the size level
-      size: '1rem', // 16px
       height: '1.25rem', // 20px
     },
-    medium: {
-      // weight needs to be modified at the size level
-      size: '1.125rem', // 18px
-      height: '1.375rem', // 22px
+    small: { // small body
+      size: '1rem', // 16px
+      height: '1.5rem', // 24px
     },
-    large: {
-      // weight needs to be modified at the size level by bumping down to 300
-      size: '1.5rem', // 24px
+    medium: { // body
+      size: '1.25rem', // 20px
       height: '1.875rem', // 30px
     },
-    xlarge: {
-      // weight needs to be modified at the size level by bumping down to 300
+    large: { // large body
+      size: '1.75rem', // 28px
+      height: '2.375rem', // 38px
+    },
+    xlarge: { // small quote
       size: '2.25rem', // 36px
-      height: '2.625rem', // 42px
+      height: '2.875rem', // 46px
     },
-    // xxlarge is not part of Chris's type exploration
-    xxlarge: {
-      // weight needs to be modified at the size level by bumping down to 300
-      size: '2.625rem', // 42px
-      height: '3rem', // 48px
+    xxlarge: { // quote
+      size: '2.75rem', // 44px
+      height: '3.375rem', // 54px
     },
-    extend: ({ size }) => {
-      if (
-        ['large', 'xlarge', 'xxlarge', '3xl', '4xl', '5xl', '6xl'].includes(
-          size,
-        )
-      )
-        return 'font-weight: 300;';
-      return '';
+    xxxlarge: { // large quote
+      size: '3.25rem', // 52px
+      height: '3.875rem', // 62px
     },
   },
 });

--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -83,7 +83,10 @@ export const hpePop = deepMerge(hpe, {
         },
       },
       3: {
-        small: {},
+        small: {
+          size: '1.75rem', // 28px
+          height: '2.125rem', // 34px
+        },
         medium: {
           size: '2.25rem', // 36px
           height: '2.625rem', // 42px
@@ -105,12 +108,12 @@ export const hpePop = deepMerge(hpe, {
       },
       4: {
         small: {
-          size: '1.125rem', // 20px
-          height: '1.125rem', // 26px
+          size: '1.25rem', // 20px
+          height: '1.625rem', // 26px
         },
         medium: {
-          size: '1.5rem', // 28px
-          height: '1.5rem', // 34px
+          size: '1.75rem', // 28px
+          height: '2.125rem', // 34px
         },
         large: {
           size: '2.25rem', // 36px
@@ -127,8 +130,8 @@ export const hpePop = deepMerge(hpe, {
           height: '1.375rem', // 22px
         },
         medium: {
-          size: '1.125rem', // 20px
-          height: '1.125rem', // 26px
+          size: '1.25rem', // 20px
+          height: '1.625rem', // 26px
         },
         large: {
           size: '1.5rem', // 28px
@@ -149,8 +152,8 @@ export const hpePop = deepMerge(hpe, {
           height: '1.375rem', // 22px
         },
         large: {
-          size: '1.125rem', // 20px
-          height: '1.125rem', // 26px
+          size: '1.25rem', // 20px
+          height: '1.625rem', // 26px
         },
         xlarge: {
           size: '2.25rem', // 36px

--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -134,8 +134,8 @@ export const hpePop = deepMerge(hpe, {
           height: '1.625rem', // 26px
         },
         large: {
-          size: '1.5rem', // 28px
-          height: '1.5rem', // 34px
+          size: '1.75rem', // 28px
+          height: '2.125rem', // 34px
         },
         xlarge: {
           size: '2.25rem', // 36px
@@ -156,13 +156,17 @@ export const hpePop = deepMerge(hpe, {
           height: '1.625rem', // 26px
         },
         xlarge: {
-          size: '2.25rem', // 36px
-          height: '2.625rem', // 42px
+          size: '1.75rem', // 28px
+          height: '2.125rem', // 34px
         },
       },
     },
     extend: ({ level, size }) => {
       let font = '';
+      // Brand direction makes use of Graphik Condensed font for marquee page titles
+      // Reserving H1 xlarge and xxlarge sizes for Condensed.
+      // Levels 2 and 3 are included for how Grommet handles responsive typography,
+      // for example enabling an H1 xlarge to downsize to an H2 xlarge at a breakpoint.
       if ([1, 2, 3].includes(level) && ['xlarge', 'xxlarge'].includes(size)) {
         font = 'font-weight: 700; font-family: GraphikXXCondensed;';
       }

--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -47,14 +47,16 @@ export const hpePop = deepMerge(hpe, {
           size: '5.25rem', // 84px
           height: '5.625rem', // 90px
         },
-        xlarge: {  // Heading condensed
+        xlarge: {
+          // Heading condensed
           size: '6rem', // 96px
           height: '6rem', // 96px
         },
-        xxlarge: { // Heading large condensed
+        xxlarge: {
+          // Heading large condensed
           size: '7rem', // 112px
           height: '7rem', // 112px
-        }
+        },
       },
       2: {
         small: {
@@ -69,19 +71,19 @@ export const hpePop = deepMerge(hpe, {
           size: '4.25rem', // 68px
           height: '4.625rem', // 74px
         },
-        xlarge: { // Heading condensed
+        xlarge: {
+          // Heading condensed
           size: '5.25rem', // 84px
           height: '5.625rem', // 90px
         },
-        xxlarge: { // Heading large condensed
+        xxlarge: {
+          // Heading large condensed
           size: '6rem', // 96px
           height: '6rem', // 96px
-        }
+        },
       },
       3: {
-        small: {
-   
-        },
+        small: {},
         medium: {
           size: '2.25rem', // 36px
           height: '2.625rem', // 42px
@@ -90,14 +92,16 @@ export const hpePop = deepMerge(hpe, {
           size: '3.25rem', // 52px
           height: '3.625rem', // 58px
         },
-        xlarge: { // Heading condensed
+        xlarge: {
+          // Heading condensed
           size: '4.25rem', // 68px
           height: '4.625rem', // 74px
         },
-        xxlarge: { // Heading large condensed
+        xxlarge: {
+          // Heading large condensed
           size: '5.25rem', // 84px
           height: '5.625rem', // 90px
-        }
+        },
       },
       4: {
         small: {
@@ -115,7 +119,7 @@ export const hpePop = deepMerge(hpe, {
         xlarge: {
           size: '3.25rem', // 52px
           height: '3.625rem', // 58px
-        }
+        },
       },
       5: {
         small: {
@@ -163,61 +167,75 @@ export const hpePop = deepMerge(hpe, {
     },
   },
   paragraph: {
-    xsmall: { // disclaimer
+    xsmall: {
+      // disclaimer
       size: '0.875rem', // 14px
       height: '1.25rem', // 20px
     },
-    small: { // small body
+    small: {
+      // small body
       size: '1rem', // 16px
       height: '1.5rem', // 24px
     },
-    medium: { // body
+    medium: {
+      // body
       size: '1.25rem', // 20px
       height: '1.875rem', // 30px
     },
-    large: { // large body
+    large: {
+      // large body
       size: '1.75rem', // 28px
       height: '2.375rem', // 38px
     },
-    xlarge: { // small quote
+    xlarge: {
+      // small quote
       size: '2.25rem', // 36px
       height: '2.875rem', // 46px
     },
-    xxlarge: { // quote
+    xxlarge: {
+      // quote
       size: '2.75rem', // 44px
       height: '3.375rem', // 54px
     },
-    xxxlarge: { // large quote
+    xxxlarge: {
+      // large quote
       size: '3.25rem', // 52px
       height: '3.875rem', // 62px
     },
   },
   text: {
-    xsmall: { // disclaimer
+    xsmall: {
+      // disclaimer
       size: '0.875rem', // 14px
       height: '1.25rem', // 20px
     },
-    small: { // small body
+    small: {
+      // small body
       size: '1rem', // 16px
       height: '1.5rem', // 24px
     },
-    medium: { // body
+    medium: {
+      // body
       size: '1.25rem', // 20px
       height: '1.875rem', // 30px
     },
-    large: { // large body
+    large: {
+      // large body
       size: '1.75rem', // 28px
       height: '2.375rem', // 38px
     },
-    xlarge: { // small quote
+    xlarge: {
+      // small quote
       size: '2.25rem', // 36px
       height: '2.875rem', // 46px
     },
-    xxlarge: { // quote
+    xxlarge: {
+      // quote
       size: '2.75rem', // 44px
       height: '3.375rem', // 54px
     },
-    xxxlarge: { // large quote
+    xxxlarge: {
+      // large quote
       size: '3.25rem', // 52px
       height: '3.875rem', // 62px
     },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds hardcoded values for marketing typography scale for `hpePop` theme.

--------------------------

This pull request updates the `hpePop` theme in `src/js/themes/hpePop.js` to refine typography styles for headings, paragraphs, and text elements. Key changes include adjustments to font sizes, line heights, font weights, and the addition of new styles for better consistency and readability.

### Typography Updates:

#### Headings:
* Adjusted font weights (e.g., `weight` changed from `400` to `500` for headings).
* Updated font sizes and line heights for various heading levels, including the introduction of new `xlarge` and `xxlarge` styles for levels 1–6.
* Refactored the `extend` function to apply condensed font styles (`font-weight: 700; font-family: GraphikXXCondensed;`) for specific heading levels and sizes.

#### Paragraphs:
* Introduced a new `xsmall` size for disclaimers and updated sizes and line heights for `small`, `medium`, `large`, `xlarge`, and `xxlarge` styles. Added a new `xxxlarge` style for large quotes.

#### Text:
* Added descriptive comments for each size category (`disclaimer`, `small body`, `body`, `large body`, `small quote`, `quote

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
