### PR TITLE
Add hpePop button styles

### DIFF
--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -1,3 +1,4 @@
+import { components, light, dark } from 'hpe-design-tokens/grommet';
 import { hpe } from './hpe';
 
 export const isObject = (item) =>
@@ -29,7 +30,118 @@ export const deepMerge = (target, ...sources) => {
   return output;
 };
 
+const getThemeColor = (color, theme) =>
+  typeof theme.global.colors[color] === 'string'
+    ? theme.global.colors[color]
+    : theme.global.colors[color]?.[theme.dark ? 'dark' : 'light'] || color;
+
+const defaultPad = {
+  small: { horizontal: '23px', vertical: '15px', iconOnly: '19px' },
+  medium: { horizontal: '35px', vertical: '19px', iconOnly: '21px' },
+  large: { horizontal: '39px', vertical: '21px', iconOnly: '23px' },
+};
+
+const createButtonSizes = (size) => ({
+  default: {
+    pad: {
+      horizontal: defaultPad[size].horizontal,
+      vertical: defaultPad[size].vertical,
+    },
+  },
+  secondary: {
+    pad: {
+      horizontal: `${parseInt(defaultPad[size].horizontal, 10) - 3}px`,
+      vertical: `${parseInt(defaultPad[size].vertical, 10) - 3}px`,
+    },
+  },
+  primary: {
+    pad: {
+      horizontal: defaultPad[size].horizontal,
+      vertical: defaultPad[size].vertical,
+    },
+  },
+  toolbar: {
+    pad: {
+      horizontal: defaultPad[size].vertical,
+      vertical: defaultPad[size].vertical,
+    },
+  },
+  iconOnly: {
+    pad: {
+      horizontal: defaultPad[size].iconOnly,
+      vertical: defaultPad[size].iconOnly,
+    },
+    secondary: {
+      pad: {
+        horizontal: `${parseInt(defaultPad[size].iconOnly, 10) - 3}px`,
+        vertical: `${parseInt(defaultPad[size].iconOnly, 10) - 3}px`,
+      },
+    },
+  },
+});
+
+const popButtonSizes = {
+  small: createButtonSizes('small'),
+  medium: createButtonSizes('medium'),
+  large: createButtonSizes('large'),
+};
+
 export const hpePop = deepMerge(hpe, {
+  button: {
+    secondary: {
+      border: {
+        width: components.hpe.button.secondary.medium.borderWidth,
+      },
+    },
+    size: {
+      ...popButtonSizes,
+    },
+    extend: ({ sizeProp, hasLabel, hasIcon, kind, theme, colorValue }) => {
+      let style = '';
+      if (sizeProp === 'large')
+        // 24px, 28px (custom instead of "large" text size)
+        style += 'font-size: 1.5rem; line-height: 1.75rem;';
+      else if (sizeProp === 'medium') style += 'line-height: 1.5rem;'; // 24px (custom instead of "medium" line-height)
+      // Grommet doesn't support kind-specific iconOnly padding, so we define it here.
+      if (kind === 'secondary' && hasIcon && !hasLabel) {
+        if (sizeProp === 'small')
+          style += `padding: ${popButtonSizes.small.iconOnly.secondary.pad.vertical};`;
+        else if (sizeProp === 'medium')
+          style += `padding: ${popButtonSizes.medium.iconOnly.secondary.pad.vertical};`;
+        else if (sizeProp === 'large')
+          style += `padding: ${popButtonSizes.large.iconOnly.secondary.pad.vertical};`;
+      }
+      if (kind === 'primary') {
+        // Temporary fix for grommet bug with light/dark logic. This temp fix will override the color prop on an icon, so this is
+        // not a long term solution. Also, reliance on !important is not ideal.
+        style += `color: ${getThemeColor(
+          'text-onSecondaryStrong',
+          theme,
+        )} !important;`;
+        const iconColor = theme.dark
+          ? dark.hpe.color.icon.onSecondaryStrong
+          : light.hpe.color.icon.onSecondaryStrong;
+        style += `svg { stroke: ${iconColor}; fill: ${iconColor}; }`;
+      }
+      if (colorValue) {
+        // color prop is not recommended to be used, but providing
+        // a better fallback behavior for hover styles to avoid
+        // "kind" hover background from applying
+        // https://github.com/grommet/grommet/issues/7504
+        style += `
+          &:hover { background: ${getThemeColor(colorValue, theme)}; }
+        `;
+      }
+      return style;
+    },
+  },
+  icon: {
+    size: {
+      small: '16px',
+      medium: '20px',
+      large: '24px',
+    },
+  },
   heading: {
     color: 'text-strong',
     weight: 400,

--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -50,6 +50,7 @@ const createButtonSizes = (size) => ({
   },
   secondary: {
     pad: {
+      // adjustment needed to accommodate border
       horizontal: `${parseInt(defaultPad[size].horizontal, 10) - 3}px`,
       vertical: `${parseInt(defaultPad[size].vertical, 10) - 3}px`,
     },
@@ -73,6 +74,7 @@ const createButtonSizes = (size) => ({
     },
     secondary: {
       pad: {
+        // adjustment needed to accommodate border
         horizontal: `${parseInt(defaultPad[size].iconOnly, 10) - 3}px`,
         vertical: `${parseInt(defaultPad[size].iconOnly, 10) - 3}px`,
       },

--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -104,12 +104,7 @@ export const hpePop = deepMerge(hpe, {
       else if (sizeProp === 'medium') style += 'line-height: 1.5rem;'; // 24px (custom instead of "medium" line-height)
       // Grommet doesn't support kind-specific iconOnly padding, so we define it here.
       if (kind === 'secondary' && hasIcon && !hasLabel) {
-        if (sizeProp === 'small')
-          style += `padding: ${popButtonSizes.small.iconOnly.secondary.pad.vertical};`;
-        else if (sizeProp === 'medium')
-          style += `padding: ${popButtonSizes.medium.iconOnly.secondary.pad.vertical};`;
-        else if (sizeProp === 'large')
-          style += `padding: ${popButtonSizes.large.iconOnly.secondary.pad.vertical};`;
+        style += `padding: ${popButtonSizes[sizeProp].iconOnly.secondary.pad.vertical};`;
       }
       if (kind === 'primary') {
         // Temporary fix for grommet bug with light/dark logic. This temp fix will override the color prop on an icon, so this is


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds button styles for hpePop flavor. Also, adjust icon sizes to align with hpePop text sizes to ensure icon and label sizing in button is proportional.

Small button: 56px height
Medium button: 64px height
Large button: 72px height

-----------------------

This pull request enhances the `hpePop` theme in `src/js/themes/hpePop.js` by introducing customizable button sizes, improving button styling logic, and adding better support for light/dark mode handling. It also includes updates to icon sizing and fixes for known issues with hover styles and color handling.

### Button Enhancements:
* Added `createButtonSizes` and `popButtonSizes` to define consistent padding and size configurations for buttons, including support for `small`, `medium`, and `large` sizes. This includes specific padding for `iconOnly` and `secondary` button styles.
* Enhanced button styling logic in the `extend` function to handle:
  - Custom font sizes and line heights for different button sizes.
  - Kind-specific `iconOnly` padding for `secondary` buttons.
  - Temporary fixes for light/dark mode inconsistencies in `primary` button icon colors.

### Icon and Theme Improvements:
* Added a `getThemeColor` utility to resolve colors based on the theme's light or dark mode.
* Updated `icon.size` to define consistent sizes (`small`, `medium`, `large`) for icons.

### Bug Fixes:
* Improved hover style logic to better handle the `color` prop and avoid unintended background changes, addressing a known issue in Grommet.


#### What testing has been done on this PR?
Local in demo app.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

<img width="388" alt="Screenshot 2025-05-21 at 10 02 32 AM" src="https://github.com/user-attachments/assets/8fef43fe-fcf5-4307-a710-e08920b02f97" />
<img width="323" alt="Screenshot 2025-05-21 at 10 01 34 AM" src="https://github.com/user-attachments/assets/008e8732-6ab7-4801-bd90-025729d50dde" />
<img width="377" alt="Screenshot 2025-05-21 at 10 01 31 AM" src="https://github.com/user-attachments/assets/ac785d1e-8761-421a-9deb-bb19b1fac638" />
<img width="380" alt="Screenshot 2025-05-21 at 10 01 27 AM" src="https://github.com/user-attachments/assets/fd16973a-8b7a-484d-ba6b-19d9f6b11805" />

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
