### PR TITLE
Ignore v2-alpha-stable on lint/build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ workflows:
                 - NEXT-stable
                 - AUDIT-stable
                 - TOKENS-stable
+                - v2-alpha-stable
                 - gh-pages
       - build:
           requires:
@@ -146,6 +147,7 @@ workflows:
                 - NEXT-stable
                 - AUDIT-stable
                 - TOKENS-stable
+                - v2-alpha-stable
                 - gh-pages
       - release-stable:
           requires:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Similar to other stable branches, ignore lint/build jobs on v2-alpha-stable.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
