### PR TITLE
V2 alpha uppercase

### DIFF
--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -279,15 +279,19 @@ export const hpePop = deepMerge(hpe, {
       },
     },
     extend: ({ level, size }) => {
-      let font = '';
+      let fontStyle = '';
       // Brand direction makes use of Graphik Condensed font for marquee page titles
       // Reserving H1 xlarge and xxlarge sizes for Condensed.
       // Levels 2 and 3 are included for how Grommet handles responsive typography,
       // for example enabling an H1 xlarge to downsize to an H2 xlarge at a breakpoint.
       if ([1, 2, 3].includes(level) && ['xlarge', 'xxlarge'].includes(size)) {
-        font = 'font-weight: 700; font-family: GraphikXXCondensed;';
+        fontStyle = `
+          font-weight: 700; 
+          font-family: GraphikXXCondensed;
+          text-transform: uppercase;
+        `;
       }
-      return font;
+      return fontStyle;
     },
   },
   paragraph: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

This pull request updates the typography styling in the `hpePop` theme to enhance readability and align with brand guidelines. The most significant change involves adding a new text transformation for specific heading levels and sizes.

### Typography updates:

* [`src/js/themes/hpePop.js`](diffhunk://#diff-a0cddec3d951e5c815bd69e89f05fd3a68e1af3fdc721421e7b1fdff3f48de91L282-R294): Renamed the variable from `font` to `fontStyle` for clarity, added `text-transform: uppercase;` to the font style for H1 headings of sizes `xlarge` and `xxlarge`, and adjusted the return value accordingly. This ensures that marquee page titles are displayed in uppercase, aligning with brand direction.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
