### PR TITLE
Fix RadioButton alignment across browsers

### DIFF
--- a/.changeset/thin-cherries-own.md
+++ b/.changeset/thin-cherries-own.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed RadioButton checked icon misalignment which was occurring on certain browsers, such as Safari, and window zoom levels.

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2105,11 +2105,13 @@ const buildTheme = (tokens, flags) => {
       icons: {
         circle: () => (
           <Blank
+            preserveAspectRatio="xMidYMid meet" // Forces uniform scaling. Part of grommet code but lost when passing custom icon.
             color={
               components.hpe.radioButton.default.control.selected.rest.iconColor
             }
+            size={components.hpe.radioButton.default.medium.control.width} // width and height are identical, so choosing one.
           >
-            <circle cx="12" cy="12" r="8" />
+            <circle cx={12} cy={12} r={6} />
           </Blank>
         ),
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

In conjunction with https://github.com/grommet/grommet/pull/7655, fixes alignment of radiobutton checked icon on browsers like Safari.

#### What testing has been done on this PR?
Local in storybook.

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

https://github.com/user-attachments/assets/1815df66-2d01-4cf2-8d77-47ad12c5c0b7

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
