### PR TITLE
Align anchor styling to design file

### DIFF
--- a/src/js/themes/hpePop.js
+++ b/src/js/themes/hpePop.js
@@ -89,6 +89,9 @@ const popButtonSizes = {
 };
 
 export const hpePop = deepMerge(hpe, {
+  anchor: {
+    textDecoration: 'none',
+  },
   button: {
     secondary: {
       border: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Removes "underline" on anchor by default to align to design file. Can revisit treatment in future when we more comprehensively systematize and address WCAG rules.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
