### PR TITLE
Fix RangeInput styles to meet WCAG AA requirements

### DIFF
--- a/.changeset/healthy-suits-shake.md
+++ b/.changeset/healthy-suits-shake.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed RangeInput styles to meet WCAG AA requirements by adding "dot" indicator at end of unselected track. This ensures that, even though the unselected track color doesn't meet 3:1 contrast ratio with background colors, there is an alternate visual indicator to define the end of the input.

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2145,7 +2145,7 @@ const buildTheme = (tokens, flags) => {
           content: '';
           width: 3px;
           height: 3px;
-          border-radius: 9999px;
+          border-radius: ${large.hpe.radius.full};
           right: 0;
           top: 50%;
           transform: translateY(-50%);

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2138,6 +2138,23 @@ const buildTheme = (tokens, flags) => {
           color: { light: 'rgb(245, 245, 245)', dark: 'rgb(44, 44, 44)' },
         },
       },
+      extend: ({ disabled, theme }) => `
+        &::before {
+          display: block;
+          position: absolute;
+          content: '';
+          width: 3px;
+          height: 3px;
+          border-radius: 9999px;
+          right: 0;
+          top: 50%;
+          transform: translateY(-50%);
+          background: ${getThemeColor(
+            disabled ? 'background-disabled' : 'background-neutral-xstrong',
+            theme,
+          )};
+        }
+    `,
     },
     select: {
       clear: {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { css } from 'styled-components';
 import {
+  primitives as localPrimitives,
   dark as localDark,
   light as localLight,
   dimension as localDimension,
@@ -153,6 +154,7 @@ const getTextSize = (size) => {
 
 const buildTheme = (tokens, flags) => {
   const {
+    primitives,
     light,
     dark,
     small,
@@ -2138,13 +2140,15 @@ const buildTheme = (tokens, flags) => {
           color: { light: 'rgb(245, 245, 245)', dark: 'rgb(44, 44, 44)' },
         },
       },
+      // primitives.hpe.base.dimension[75] = 3px which is WCAG minimum size
+      // for visual indicator
       extend: ({ disabled, theme }) => `
         &::before {
           display: block;
           position: absolute;
           content: '';
-          width: 3px;
-          height: 3px;
+          width: ${primitives.hpe.base.dimension[75]};
+          height: ${primitives.hpe.base.dimension[75]};
           border-radius: ${large.hpe.radius.full};
           right: 0;
           top: 50%;
@@ -2503,6 +2507,7 @@ const buildTheme = (tokens, flags) => {
 
 export const hpe = buildTheme(
   {
+    primitives: localPrimitives,
     light: localLight,
     dark: localDark,
     small: localSmall,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds "dot" treatment on unselected end of track to ensure appropriate affordance for end of track. At 3px by 3px, a minimum contrast ratio of 3:1 is required, which we more than exceed with the chosen semantic color.

#### What testing has been done on this PR?

rest + disabled states

<img width="439" alt="Screenshot 2025-06-10 at 12 39 31 PM" src="https://github.com/user-attachments/assets/c01349da-7045-4fd5-beac-55eb236c19b7" />


Tested contrast ratios.

<img width="813" alt="Screenshot 2025-06-10 at 12 38 49 PM" src="https://github.com/user-attachments/assets/7c5a60bd-f89c-452a-b733-f09960e10170" />

#### Any background context you want to provide?

#### What are the relevant issues?

Closes https://github.com/grommet/grommet-theme-hpe/issues/461

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible

#### How should this PR be communicated in the release notes?
