### PR TITLE
Update version

### DIFF
--- a/.changeset/healthy-suits-shake.md
+++ b/.changeset/healthy-suits-shake.md
@@ -1,5 +1,0 @@
----
-"grommet-theme-hpe": patch
----
-
-- Fixed RangeInput styles to meet WCAG AA requirements by adding "dot" indicator at end of unselected track. This ensures that, even though the unselected track color doesn't meet 3:1 contrast ratio with background colors, there is an alternate visual indicator to define the end of the input.

--- a/.changeset/loud-adults-admire.md
+++ b/.changeset/loud-adults-admire.md
@@ -1,5 +1,0 @@
----
-"grommet-theme-hpe": patch
----
-
-- Fixed Calendar disabled day styles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # grommet-theme-hpe
 
+## 6.4.1
+
+### Patch Changes
+
+- e6abbd6: - Fixed RangeInput styles to meet WCAG AA requirements by adding "dot" indicator at end of unselected track. This ensures that, even though the unselected track color doesn't meet 3:1 contrast ratio with background colors, there is an alternate visual indicator to define the end of the input.
+- 695c1be: - Fixed Calendar disabled day styles.
+
 ## 6.4.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grommet-theme-hpe",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "main": "dist/index.js",
   "module": "dist/es6/index.js",
   "jsnext:main": "dist/es6/index.js",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

`yarn changeset version`

#### What testing has been done on this PR?

Tested locally with `stable` branch in test app:

<img width="442" alt="Screenshot 2025-06-16 at 2 06 12 PM" src="https://github.com/user-attachments/assets/404df55e-054f-40ec-9d99-ef1947abd37d" />

In this the Calendar day "14" is correctly disabled

<img width="444" alt="Screenshot 2025-06-16 at 2 07 50 PM" src="https://github.com/user-attachments/assets/01af3a00-cb68-41e3-81bc-c0d532484e06" />

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
