### PR TITLE
Fix RangeInput styling for Firefox

### DIFF
--- a/.changeset/forty-seas-cough.md
+++ b/.changeset/forty-seas-cough.md
@@ -2,5 +2,5 @@
 "grommet-theme-hpe": patch
 ---
 
-- Fixed RangeInput styling for Firefox which does not support pseudo-element on input tag. In the future, we might consider rebuilding the Grommet RangeInput to accomodate the "dot" marker across all browsers. For now, applying this styling for FireFox to meet WCAG AA guidelines.
+- Fixed RangeInput styling for Firefox which does not support pseudo-element on input tag. In the future, we might consider rebuilding the Grommet RangeInput to accommodate the "dot" marker across all browsers. For now, applying this styling for FireFox to meet WCAG AA guidelines.
 - For all other browsers (non-FireFox), increased "dot" marker from 3px to 4px to match the height of the RangeInput track.

--- a/.changeset/forty-seas-cough.md
+++ b/.changeset/forty-seas-cough.md
@@ -1,0 +1,6 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed RangeInput styling for Firefox which does not support pseudo-element on input tag. In the future, we might consider rebuilding the Grommet RangeInput to accomodate the "dot" marker across all browsers. For now, applying this styling for FireFox to meet WCAG AA guidelines.
+- For all other browsers (non-FireFox), increased "dot" marker from 3px to 4px to match the height of the RangeInput track.

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2121,7 +2121,10 @@ const buildTheme = (tokens, flags) => {
       container: { cssGap: true, gap: 'small', margin: 'none' },
     },
     rangeInput: {
-      thumb: { color: 'background-primary-strong' },
+      thumb: {
+        color: 'background-primary-strong',
+        extend: 'border-color: transparent;', // fix for FireFox
+      },
       track: {
         lower: { color: 'background-primary-strong' },
         upper: {
@@ -2129,7 +2132,13 @@ const buildTheme = (tokens, flags) => {
           // https://github.com/grommet/grommet/issues/6739
           color: { light: '#e0e0e0', dark: '#616161' },
         },
-        extend: () => `border-radius: ${large.hpe.radius.full};`,
+        extend: ({ theme }) => `
+        border-radius: ${large.hpe.radius.full};
+        // firefox only selector, since pseudo-element
+        // isn't supported
+        @-moz-document url-prefix() {
+          border: 1px solid ${getThemeColor('border-strong', theme)};
+        }`,
       },
       disabled: {
         opacity: 1,
@@ -2140,15 +2149,15 @@ const buildTheme = (tokens, flags) => {
           color: { light: 'rgb(245, 245, 245)', dark: 'rgb(44, 44, 44)' },
         },
       },
-      // primitives.hpe.base.dimension[75] = 3px which is WCAG minimum size
-      // for visual indicator
+      // primitives.hpe.base.dimension[100] = 4px which meets WCAG minimum size
+      // for visual indicator (minimum 3px)
       extend: ({ disabled, theme }) => `
         &::before {
           display: block;
           position: absolute;
           content: '';
-          width: ${primitives.hpe.base.dimension[75]};
-          height: ${primitives.hpe.base.dimension[75]};
+          width: ${primitives.hpe.base.dimension[100]};
+          height: ${primitives.hpe.base.dimension[100]};
           border-radius: ${large.hpe.radius.full};
           right: 0;
           top: 50%;


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Refine RangeInput styling for Firefox based on designer input. `pseudo` elements are not supported on selfclosing HTML tags (like input). Safari/Chrome are more forgiving on this, but Firefox is strict so the "dot" indicator is not coming through.

For Firefox only, we'll do a thin border around the track for the time being. Otherwise, we'd need to rebuild the component in grommet to have the "dot" styling across all browsers.

#### What testing has been done on this PR?

Locally on Firefox:
<img width="381" alt="Screenshot 2025-07-01 at 3 41 05 PM" src="https://github.com/user-attachments/assets/eda5650c-5564-4420-90c6-93385f1d6799" />


#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet-theme-hpe/issues/461

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
