### PR TITLE
Add `global.focus.inset`

### DIFF
--- a/.changeset/heavy-fireants-walk.md
+++ b/.changeset/heavy-fireants-walk.md
@@ -2,4 +2,4 @@
 "grommet-theme-hpe": minor
 ---
 
-- Added `global.focus.inset` for cases like DataTable expand control which leverages `focusIndicator="inset"` internally. Supported when using grommet >=2.X.0.
+- Added `global.focus.inset` for cases like DataTable expand control which leverages `focusIndicator="inset"` internally. Supported when using grommet >=2.48.0.

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -630,21 +630,19 @@ const buildTheme = (tokens, flags) => {
         },
         twoColor: true,
         inset: {
-          inset: {
-            border: undefined,
-            outline: {
-              color: global.hpe.focusIndicator.outline.color,
-              size: global.hpe.focusIndicator.outline.width,
-              offset: `-${global.hpe.focusIndicator.outline.width}`,
-            },
-            shadow: {
-              color: focusBoxShadowParts[focusBoxShadowParts.length - 1],
-              size: '4px',
-              blur: '0px',
-              inset: true,
-            },
-            twoColor: true,
+          border: undefined,
+          outline: {
+            color: global.hpe.focusIndicator.outline.color,
+            size: global.hpe.focusIndicator.outline.width,
+            offset: `-${global.hpe.focusIndicator.outline.width}`,
           },
+          shadow: {
+            color: focusBoxShadowParts[focusBoxShadowParts.length - 1],
+            size: '4px',
+            blur: '0px',
+            inset: true,
+          },
+          twoColor: true,
         },
       },
       active: { background: 'background-active', color: 'active-text' },

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -629,6 +629,23 @@ const buildTheme = (tokens, flags) => {
           size: focusBoxShadowParts[focusBoxShadowParts.length - 2],
         },
         twoColor: true,
+        inset: {
+          inset: {
+            border: undefined,
+            outline: {
+              color: global.hpe.focusIndicator.outline.color,
+              size: global.hpe.focusIndicator.outline.width,
+              offset: `-${global.hpe.focusIndicator.outline.width}`,
+            },
+            shadow: {
+              color: focusBoxShadowParts[focusBoxShadowParts.length - 1],
+              size: '4px',
+              blur: '0px',
+              inset: true,
+            },
+            twoColor: true,
+          },
+        },
       },
       active: { background: 'background-active', color: 'active-text' },
       drop: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Adds `global.focus.inset` for cases like "expand" control in DataTable where focus needs to be inset in the container to show.

**Note to reviewers**

@jcfilben @britt6612 We can discuss if this should be a "major" change (since it won't actually come through unless someone is on the grommet version that includes this enhancement) or a "minor" change (it would come through for teams that are on the latest, but it wouldn't break anything for teams on older versions).

#### What testing has been done on this PR?

Locally in Design System site.

<img width="753" height="482" alt="Screenshot 2025-07-10 at 4 10 19 PM" src="https://github.com/user-attachments/assets/be0af753-2491-4eb8-838f-c39820032070" />
<img width="749" height="480" alt="Screenshot 2025-07-10 at 4 10 10 PM" src="https://github.com/user-attachments/assets/0742ec2f-5735-45b8-8aa8-ed99e57d3b96" />

#### Any background context you want to provide?

#### What are the relevant issues?
Closes https://github.com/grommet/grommet/issues/7336

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
