### PR TITLE
Fix `global.focus.shadow.blur`

### DIFF
--- a/.changeset/nine-emus-change.md
+++ b/.changeset/nine-emus-change.md
@@ -2,4 +2,4 @@
 "grommet-theme-hpe": patch
 ---
 
-- Fixed `global.focus.blur` to be intended value of `0px` instead of `2px`.
+- Fixed `global.focus.shadow.blur` to be intended value of `0px` instead of `2px`.

--- a/.changeset/nine-emus-change.md
+++ b/.changeset/nine-emus-change.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed `global.focus.blur` to be intended value of `0px` instead of `2px`.

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -627,6 +627,7 @@ const buildTheme = (tokens, flags) => {
         shadow: {
           color: focusBoxShadowParts[focusBoxShadowParts.length - 1],
           size: focusBoxShadowParts[focusBoxShadowParts.length - 2],
+          blur: '0px',
         },
         twoColor: true,
       },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

The intended style is for the boxShadow (used for dark mode focus indicator) to not have any blur. This fixes that. Previously it was falling back to the default `2px` blur.

#### What testing has been done on this PR?

Local in DS site:

BEFORE:
<img width="322" height="82" alt="Screenshot 2025-07-10 at 4 11 06 PM" src="https://github.com/user-attachments/assets/c6255f27-5236-428d-b306-3132896aa483" />

AFTER:
<img width="325" height="121" alt="Screenshot 2025-07-10 at 4 11 00 PM" src="https://github.com/user-attachments/assets/b10e277a-b414-4842-9245-7eb69a9537a8" />

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
