### PR TITLE
Enhance theme-driven "bold" weight

### DIFF
--- a/.changeset/hungry-donuts-crash.md
+++ b/.changeset/hungry-donuts-crash.md
@@ -1,5 +1,5 @@
 ---
-"grommet-theme-hpe": patch
+"grommet-theme-hpe": major
 ---
 
 - Updated Text and Heading such that passing `weight="bold"` will resolve to theme-defined weight of 500. This enables the concept of "bold" to be theme-driven. For use cases that need the font-face's true bold, numeric font-weights 800 can be used and won't be overridden. 

--- a/.changeset/hungry-donuts-crash.md
+++ b/.changeset/hungry-donuts-crash.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Updated Text and Heading such that passing `weight="bold"` will resolve to theme-defined weight of 500. This enables the concept of "bold" to be theme-driven. For use cases that need the font-face's true bold, numeric font-weights 800 can be used and won't be overridden. 

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -379,11 +379,17 @@ const buildTheme = (tokens, flags) => {
       large.hpe.text?.[textSize]?.fontWeight || fallback.weight;
   });
 
-  textTheme.extend = ({ size: textSize, weight }) =>
-    !weight ? `font-weight: ${fontWeights[textSize]};` : '';
+  textTheme.extend = ({ size: textSize, weight }) => {
+    if (!weight) return `font-weight: ${fontWeights[textSize]};`;
+    if (weight === 'bold') return `font-weight: 500;`;
+    return '';
+  };
 
-  paragraphTheme.extend = ({ size: textSize, weight }) =>
-    !weight ? `font-weight: ${fontWeights[textSize]};` : '';
+  paragraphTheme.extend = ({ size: textSize, weight }) => {
+    if (!weight) return `font-weight: ${fontWeights[textSize]};`;
+    if (weight === 'bold') return `font-weight: 500;`;
+    return '';
+  };
 
   const buttonKindTheme = {};
   buttonKinds.forEach((kind) => {
@@ -1707,7 +1713,7 @@ const buildTheme = (tokens, flags) => {
           },
         },
       },
-      extend: () => '',
+      extend: ({ weight }) => (weight === 'bold' ? 'font-weight: 500;' : ''),
     },
     icon: {
       disableScaleDown: true,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
It is beneficial to drive what the font-weight string "bold" should resolve to via the theme. A few major versions ago, we instructed that "bold" treatment should really now use "medium" to evolve with HPE's brand, however leaving it up to individual teams to implement this poses additional remapping work and room for divergence.

This PR changes the behavior of Text / Heading such that:
- If the caller passes `weight="bold"`, it will resolve to whatever we define "bold" to mean in the theme (at the current state, 500)
- If the caller passes weight as a string/number (for example, `weight={800}` or `weight="800"`), we will respect the specific weight they passed.

This allows the concept of "bold" to be theme-driven, while still allowing the caller to override via the specific numeric string if a true bold is needed for a use case.

#### What testing has been done on this PR?

Locally in DS site

<img width="854" height="312" alt="Screenshot 2025-07-21 at 4 30 19 PM" src="https://github.com/user-attachments/assets/ff15587b-e4e7-4ae4-afbb-01b428168728" />

#### Any background context you want to provide?

#### What are the relevant issues?

Closes #481 

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
