### PR TITLE
Updated version

### DIFF
--- a/.changeset/heavy-fireants-walk.md
+++ b/.changeset/heavy-fireants-walk.md
@@ -1,5 +1,0 @@
----
-"grommet-theme-hpe": minor
----
-
-- Added `global.focus.inset` for cases like DataTable expand control which leverages `focusIndicator="inset"` internally. Supported when using grommet >=2.48.0.

--- a/.changeset/nine-emus-change.md
+++ b/.changeset/nine-emus-change.md
@@ -1,5 +1,0 @@
----
-"grommet-theme-hpe": patch
----
-
-- Fixed `global.focus.shadow.blur` to be intended value of `0px` instead of `2px`.

--- a/.changeset/stupid-candles-eat.md
+++ b/.changeset/stupid-candles-eat.md
@@ -1,7 +1,0 @@
----
-"grommet-theme-hpe": minor
----
-
-- Upgraded hpe-design-tokens to next minor version.
-  - Added `color.icon.primary.hover`. In Grommet, used as `color="icon-primary-hover"`.
-  - Fixed value of `checkbox.control.indeterminate.rest.iconColor` from `color.icon.onPrimaryStrong` to `color.icon.onSelectedPrimaryStrong`. No visual change for this theme version, but fixes reference to be more scalable to future theme changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # grommet-theme-hpe
 
+## 6.5.0
+
+### Minor Changes
+
+- 55b537b: - Upgraded hpe-design-tokens to next minor version.
+  - Added `color.icon.primary.hover`. In Grommet, used as `color="icon-primary-hover"`.
+  - Fixed value of `checkbox.control.indeterminate.rest.iconColor` from `color.icon.onPrimaryStrong` to `color.icon.onSelectedPrimaryStrong`. No visual change for this theme version, but fixes reference to be more scalable to future theme changes.
+- fe34cae: - Added `global.focus.inset` for cases like DataTable expand control which leverages `focusIndicator="inset"` internally. Supported when using grommet >=2.48.0.
+
+### Patch Changes
+
+- 5f82fd6: - Fixed `global.focus.shadow.blur` to be intended value of `0px` instead of `2px`.
+
 ## 6.4.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grommet-theme-hpe",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "main": "dist/index.js",
   "module": "dist/es6/index.js",
   "jsnext:main": "dist/es6/index.js",


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

`yarn changeset version`

#### What testing has been done on this PR?

Tested in local sample app with latest grommet version and older grommet version to ensure to issues with `global.focus.inset`

With latest grommet functionality:

<img width="586" height="205" alt="Screenshot 2025-07-31 at 11 06 03 AM" src="https://github.com/user-attachments/assets/eb474a17-160f-4a52-bae0-f0e98ef08399" />
<img width="963" height="214" alt="Screenshot 2025-07-31 at 11 05 54 AM" src="https://github.com/user-attachments/assets/07520348-2353-4598-907f-d6494b80a511" />


#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
