### PR TITLE
Add dataTableColumns theme object

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1365,6 +1365,22 @@ const buildTheme = (tokens, flags) => {
         hover: { border: { color: 'border-strong', size: 'small' } },
       },
     },
+    dataTableColumns: {
+      tabs: {
+        pad: 'xsmall',
+      },
+      selectColumns: {
+        pad: {
+          vertical: 'xsmall',
+        },
+        gap: '3xsmall',
+      },
+      orderColumns: {
+        pad: {
+          top: 'xsmall',
+        },
+      },
+    },
     fileInput: {
       border: {
         color:


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- add tabs pad theme object
- add selectColumns pad vertical pad and gap theme object
- add orderColumns top pad theme object

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
