### PR TITLE
Fix headerCell, footerCell padding

### DIFF
--- a/.changeset/perfect-ladybugs-hunt.md
+++ b/.changeset/perfect-ladybugs-hunt.md
@@ -1,0 +1,5 @@
+---
+"grommet-theme-hpe": patch
+---
+
+- Fixed missing design token mapping for padding of table header and footer cells to align with hpe-design-tokens and Figma. Height of header cells changes from 36px to 48px, in alignment with body cell styling.

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2369,6 +2369,11 @@ const buildTheme = (tokens, flags) => {
     },
     table: {
       header: {
+        pad: {
+          horizontal: components.hpe.headerCell.default.medium.paddingX,
+          top: components.hpe.headerCell.default.medium.paddingTop,
+          bottom: components.hpe.headerCell.default.medium.paddingBottom,
+        },
         extend: `
           > div { 
             height: 100%;
@@ -2393,6 +2398,11 @@ const buildTheme = (tokens, flags) => {
       },
       row: { hover: { background: 'background-hover' } },
       footer: {
+        pad: {
+          horizontal: components.hpe.footerCell.default.medium.paddingX,
+          top: components.hpe.footerCell.default.medium.paddingTop,
+          bottom: components.hpe.footerCell.default.medium.paddingBottom,
+        },
         extend: `
           font-weight: ${components.hpe.footerCell.default.fontWeight};
         `,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Table theme object was missing token mappings for header and footer cell paddings, creating a discrepancy between hpe-design-tokens and grommet-theme-hpe. Previously, header and footer cells had incorrectly rendered as 36px instead of 48px.

#### What testing has been done on this PR?
Locally in DS site (AFTER)

Footer cell

<img width="643" height="473" alt="Screenshot 2025-08-25 at 2 59 29 PM" src="https://github.com/user-attachments/assets/b3427f33-f63e-43b9-917a-8777f3ec8b73" />

Header cell
<img width="657" height="455" alt="Screenshot 2025-08-25 at 2 59 23 PM" src="https://github.com/user-attachments/assets/64423e65-b6e1-46ea-8103-c3c491799517" />


#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
