### PR TITLE
Change box theme prop name

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -778,7 +778,7 @@ const buildTheme = (tokens, flags) => {
     },
     box: {
       border: {
-        size: '3xsmall',
+        offset: '3xsmall',
       },
     },
     button: {


### PR DESCRIPTION
#### What does this PR do?
Updates `theme.box.border.size` to `theme.box.border.offset` based on change made here: https://github.com/grommet/grommet/pull/7789

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
