### PR TITLE
Bump grommet peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "bugs": "https://github.com/grommet/grommet-theme-hpe/issues",
   "license": "Apache-2.0",
   "repository": {
+    "type": "git",
     "url": "https://github.com/grommet/grommet-theme-hpe.git"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Grommet needs to be at at least v2.49.0 to have support for the necessary theme objects

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
