### PR TITLE
Add DataTable resizer padding t-shirt size

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1526,6 +1526,9 @@ const buildTheme = (tokens, flags) => {
       resize: {
         border: { color: 'border', side: 'end' },
         hover: { border: { color: 'border-strong', size: 'small' } },
+        padding: {
+          vertical: '3xsmall',
+        },
       },
       search: {
         pad: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Related to changes here: https://github.com/grommet/grommet/pull/7804

Adds the updated t-shirt size to the theme dataTable.resize.padding.vertical property

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
