### PR TITLE
Fix box shadow to align with tokens structure

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -585,10 +585,6 @@ const buildTheme = (tokens, flags) => {
     };
   });
 
-  const focusBoxShadowParts = global.hpe.focusIndicator.boxShadow
-    .trim()
-    .split(' ');
-
   return deepFreeze({
     defaultMode: 'light',
     global: {
@@ -722,8 +718,8 @@ const buildTheme = (tokens, flags) => {
           offset: global.hpe.focusIndicator.outlineOffset,
         },
         shadow: {
-          color: focusBoxShadowParts[focusBoxShadowParts.length - 1],
-          size: focusBoxShadowParts[focusBoxShadowParts.length - 2],
+          color: global.hpe.focusIndicator.boxShadow.color,
+          size: global.hpe.focusIndicator.boxShadow.spread,
           blur: '0px',
         },
         twoColor: true,
@@ -735,7 +731,7 @@ const buildTheme = (tokens, flags) => {
             offset: `-${global.hpe.focusIndicator.outline.width}`,
           },
           shadow: {
-            color: focusBoxShadowParts[focusBoxShadowParts.length - 1],
+            color: global.hpe.focusIndicator.boxShadow.color,
             size: '4px',
             blur: '0px',
             inset: true,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Changes how the theme references focus indicator box shadow to align with the tokens changes here: https://github.com/grommet/hpe-design-system/pull/5407

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
