### PR TITLE
add fallback for heading size that is not in tokens

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -118,6 +118,12 @@ const breakpointStyle = (global, content, responsive) => {
   return st.join('');
 };
 
+const themeDefaultSize = 'medium';
+const getHeadingSize = (breakpointTokens, size) =>
+  size && breakpointTokens.hpe.heading[size]
+    ? breakpointTokens.hpe.heading[size]
+    : breakpointTokens.hpe.heading[themeDefaultSize];
+
 const getThemeColor = (color, theme) =>
   typeof theme.global.colors[color] === 'string'
     ? theme.global.colors[color]
@@ -2019,19 +2025,10 @@ const buildTheme = (tokens, flags) => {
       },
       extend: ({ size: headingSize, level, weight, responsive }) => {
         let style = '';
-        let fontSize = '';
-        let lineHeight = '';
-        let fontWeight = '';
-
-        // Add fallback to 'medium' if headingSize doesn't exist in tokens
-        const fallbackHeadingSize =
-          headingSize && large.hpe.heading[headingSize]
-            ? headingSize
-            : 'medium';
-
-        fontSize = large.hpe.heading[fallbackHeadingSize]?.fontSize;
-        lineHeight = large.hpe.heading[fallbackHeadingSize]?.lineHeight;
-        fontWeight = large.hpe.heading[fallbackHeadingSize]?.fontWeight;
+        const { fontSize, lineHeight, fontWeight } = getHeadingSize(
+          large,
+          headingSize,
+        );
 
         if (fontWeight && !weight) style += `font-weight: ${fontWeight};`;
         if (fontSize) style += `font-size: ${fontSize};`;
@@ -2039,25 +2036,18 @@ const buildTheme = (tokens, flags) => {
         // The max desired weight in the the theme is 500, however a common convention is for
         // implementors to choose "bold" to style text. This ensures bold resolves to the desired wieght.
         if (weight === 'bold') style += 'font-weight: 500;';
-        if (size) {
+
+        if (responsive) {
           const responsiveSize = headingSize || headingLevelToSize[level || 1];
-          // Add same fallback logic for responsive sizing
-          const fallbackResponsiveSize =
-            responsiveSize && small.hpe.heading[responsiveSize]
-              ? responsiveSize
-              : 'medium';
+          const responsiveHeadingSize = getHeadingSize(small, responsiveSize);
 
           style += breakpointStyle(
             localGlobal,
             `
-              font-size: ${small.hpe.heading[fallbackResponsiveSize].fontSize};
-              line-height: ${small.hpe.heading[fallbackResponsiveSize].lineHeight};
-              ${
-                !weight
-                  ? `font-weight: ${small.hpe.heading[fallbackResponsiveSize].fontWeight}`
-                  : ''
-              };
-            `,
+        font-size: ${responsiveHeadingSize.fontSize};
+        line-height: ${responsiveHeadingSize.lineHeight};
+        ${!weight ? `font-weight: ${responsiveHeadingSize.fontWeight}` : ''};
+      `,
             responsive,
           );
         }


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes a bug where if someone passed `xxlarge` to Heading. 

Our design tokens  only define these sizes for Heading:
`xxsmall` `xsmall` `small` `medium` `large` `xlarge`
So when someone passes `xxlarge` to size it tries to look for the token `xxlarge` and that does exist, so the fontSize becomes undefined
Im not sure if this was on purpose to not have `xxlarge` but thinking we should add a fall back or something for this
#### What testing has been done on this PR?
locally 
#### Any background context you want to provide?
none
#### What are the relevant issues?
closes https://github.com/grommet/grommet-theme-hpe/issues/553
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backward compatible
#### How should this PR be communicated in the release notes?
yes