### PR TITLE
update places that grommet had icons defined to use the new hpe icons

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -41,7 +41,7 @@ import { Pin } from '@hpe-design/icons-grommet/icons/Pin';
 import { StatusWarning } from '@hpe-design/icons-grommet/icons/StatusWarning';
 import { StatusGood } from '@hpe-design/icons-grommet/icons/StatusGood';
 import { StatusUnknown } from '@hpe-design/icons-grommet/icons/StatusUnknown';
-import { Info } from '@hpe-design/icons-grommet/icons/Info';
+import { StatusInfo } from '@hpe-design/icons-grommet/icons/Info';
 import { StatusCritical } from '@hpe-design/icons-grommet/icons/StatusCritical';
 
 import { backgrounds } from './backgrounds';


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR updates the area's in which Grommet was setting icons in the base theme to icons from `grommet-icons`
#### What testing has been done on this PR?
locally 
#### Any background context you want to provide?
There were icons defined in the Grommet `base.js` file that are pointing to `grommet-icons` we need to update any reference to those icons to the new hpe-icons set
#### What are the relevant issues?
closes #https://github.com/grommet/grommet-theme-hpe/issues/554
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
