### PR TITLE
Remove stroke override from primary button icon

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1051,7 +1051,7 @@ const buildTheme = (tokens, flags) => {
           const iconColor = theme.dark
             ? dark.hpe.color.icon.onStrong
             : light.hpe.color.icon.onStrong;
-          style += `svg { stroke: ${iconColor}; fill: ${iconColor}; }`;
+          style += `svg { fill: ${iconColor}; }`;
         }
         if (colorValue) {
           // color prop is not recommended to be used, but providing


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Remove stroke override from the primary button theme.

Having this stroke resulted in the following issue where there is a white outline around brand icons within primary buttons

<img width="333" height="90" alt="Screenshot 2025-11-12 at 3 47 50 PM" src="https://github.com/user-attachments/assets/701c548f-6bec-4039-a78d-068aea01b9a7" />

Here is how the icon looks after this fix in this PR:
<img width="164" height="61" alt="Screenshot 2025-11-12 at 3 49 18 PM" src="https://github.com/user-attachments/assets/699fe1f1-a41b-4586-b7ed-f7bea3b7f6b8" />

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
Resolved an issue with the stroke color of icons on primary buttons.