### PR TITLE
Select search icon

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2781,7 +2781,7 @@ const buildTheme = (tokens, flags) => {
       icons: {
         color: 'icon',
         down: Down,
-        search: Search,
+        search: <Search aria-hidden />,
         margin: {
           left: 'xsmall',
           // setting right margin to 12px because on small


### PR DESCRIPTION
#### What does this PR do?
Use @hpe-design/icons-grommet icon for search in Select. Related to this grommet pr: https://github.com/grommet/grommet/pull/7836

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)
Before
<img width="281" height="196" alt="Screenshot 2025-11-17 at 9 43 04 AM" src="https://github.com/user-attachments/assets/dd33c1a4-d381-491b-b4e6-3b1f0e3e2b58" />


After
<img width="304" height="165" alt="Screenshot 2025-11-17 at 9 42 20 AM" src="https://github.com/user-attachments/assets/7d1a7375-4da4-49d0-8858-7695bcc1e043" />

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backwards compatible
#### How should this PR be communicated in the release notes?
Adjusted Select and SelectMultiple search icon to use the Search icon from @hpe-design/icons-grommet