### PR TITLE
Add theme support for thumbs and star rating components

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1866,12 +1866,6 @@ const buildTheme = (tokens, flags) => {
                     .borderColor
             }; `,
         },
-        icons: {
-          like: Like,
-          likeSelected: LikeFill,
-          dislike: Dislike,
-          dislikeSelected: DislikeFill,
-        },
       },
       starRating: {
         container: {
@@ -1927,10 +1921,6 @@ const buildTheme = (tokens, flags) => {
         size: 'xsmall',
         color: components.hpe.formField.default.help.rest.color,
         margin: 'none',
-      },
-      icons: {
-        selected: StarFill,
-        unselected: Star,
       },
       info: {
         size: 'xsmall',


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
- Add theme support for thumbs and star rating components

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?
closes https://github.com/grommet/grommet/issues/7840

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
