### PR TITLE
Set meter background to background-contrast

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -2167,6 +2167,7 @@ const buildTheme = (tokens, flags) => {
       },
     },
     meter: {
+      background: 'background-contrast',
       gap: '5xsmall',
     },
     nameValueList: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Set theme.meter.background to `background-contrast` instead of falling back to the default grommet value.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible

#### How should this PR be communicated in the release notes?
