### PR TITLE
Change StarRating and ThumbsRating icons to use hpe set

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1866,12 +1866,6 @@ const buildTheme = (tokens, flags) => {
                     .borderColor
             }; `,
         },
-        icons: {
-          like: Like,
-          likeSelected: LikeFill,
-          dislike: Dislike,
-          dislikeSelected: DislikeFill,
-        },
       },
       starRating: {
         container: {
@@ -1927,10 +1921,6 @@ const buildTheme = (tokens, flags) => {
         size: 'xsmall',
         color: components.hpe.formField.default.help.rest.color,
         margin: 'none',
-      },
-      icons: {
-        selected: StarFill,
-        unselected: Star,
       },
       info: {
         size: 'xsmall',
@@ -2881,6 +2871,10 @@ const buildTheme = (tokens, flags) => {
     },
     starRating: {
       color: 'background-selected-primary-strong',
+      icons: {
+        selected: StarFill,
+        unselected: Star,
+      },
     },
     tab: {
       color: 'text',
@@ -3114,6 +3108,12 @@ const buildTheme = (tokens, flags) => {
     thumbsRating: {
       like: { color: 'background-selected-primary-strong' },
       dislike: { color: 'background-selected-primary-strong' },
+      icons: {
+        dislike: Dislike,
+        dislikeSelected: DislikeFill,
+        like: Like,
+        likeSelected: LikeFill,
+      },
     },
     toggleGroup: {
       button: { kind: 'toolbar' },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Removes incorrect theme code where we were attempting to set the icons within the FormField object of the theme. Adds icon assignment to the StarRating and ThumbsRating theme objects

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Backwards compatible
#### How should this PR be communicated in the release notes?
