### PR TITLE
Update installation instructions for grommet-theme-hpe

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Hewlett Packard Enterprise design system theme.
   $ yarn add grommet-theme-hpe @hpe-design/icons-grommet
 ```
 
-Note `@hpe-design/icons-grommet` is a peer dependency of grommet-theme-hpe and must be installed explicitly.
+`@hpe-design/icons-grommet` is a peer dependency of grommet-theme-hpe and must be installed explicitly.
 
 _NOTE: To install `grommet-theme-hpe` from a branch, use the `yarn` package
 manager, since `npm install` fails to install from a branch name. `npm install`


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Added note about peer dependency for grommet-theme-hpe.
#### What testing has been done on this PR?
none needed
#### Any background context you want to provide?
this convo 

```
Viktor Shevchenko
  [Today at 2:26 PM](https://hpe.slack.com/archives/C04LMJWQT/p1765920364598749)
One more thing I wanted to let you know, is due to @hpe-design/icons-grommet is a peer dependency of grommet-theme-hpe it has to be explicitly installed. I would suggest either to move it to dependencies or to update documentation. This is not mentioned here https://github.com/grommet/grommet-theme-hpe or here https://design-system.hpe.design/foundation/developer-guidance#applying-the-hpe-theme (probably I am looking in a wrong place...)
In my option
npm i grommet styled-components grommet-theme-hpe @hpe-design/icons-grommet

import { Grommet } from 'grommet';
import { hpe } from 'grommet-theme-hpe';

<Grommet theme={hpe} />
  <App/>
</Grommet>
Should be the first thing develop see when he land on HPE design system website
```

we also are going to discuss as a dev group


#### What are the relevant issues?
none
#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backward compatible
#### How should this PR be communicated in the release notes?
no