### PR TITLE
Checkbox – Fixed checkmark color

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1397,10 +1397,11 @@ const buildTheme = (tokens, flags) => {
       },
       icon: {
         extend: ({ theme, disabled }) => {
-          // Reverse the theme mode for selected state because the
-          // icon-onSelectedPrimaryStrong color token was intentionally swapped
-          // (light/dark values reversed) in the color definitions. This reversal
-          // "un-swaps" the token to display the correct icon color in both modes.
+          // Grommet normally applies a "smart" background/foreground pairing that
+          // selects foreground colors based on the background (light/dark) to keep
+          // text and icons readable. Because the "icon-onSelectedPrimaryStrong" token's
+          // light/dark values are intentionally swapped in our tokens, invert
+          // theme.dark here so the token is resolved exactly as authored.
           const themeToUse = disabled ? theme : { ...theme, dark: !theme.dark };
           return `stroke-width: 2px;
       stroke: ${getThemeColor(


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes the checkbox checkmark icon color to properly display in both light and dark modes. The checkmark now correctly uses the `icon-onSelectedPrimaryStrong` token with reversed dark/light logic to account for the swapped color token definitions.
#### What testing has been done on this PR?
Tested checkbox in light/dark mode

#### Any background context you want to provide?
The `icon-onSelectedPrimaryStrong` color token was previously swapped (light/dark values reversed) in the color definitions. This caused the checkbox checkmark to display with inverted colors - showing light in light mode and dark in dark mode. The fix reverses the theme logic specifically for the selected checkbox icon to "un-swap" the color token and display the correct colors.
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backward compatible 
#### How should this PR be communicated in the release notes?
Checkbox checkmark icon now displays with correct colors in both light and dark modes