### PR TITLE
Changed boxShadow focus format to align with token change

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -600,6 +600,10 @@ const buildTheme = (tokens, flags) => {
   const backgroundDeprecationMessage = (background) =>
     `The background "${background}" is deprecated and will be removed in v9 to ensure access to the latest Brand assets. Please replace this key by referencing an image URL directly. You can find approved backgrounds within HPE Brand Central (https://brandcentral.hpe.com/brand-central/content/imagery).`;
 
+  const focusBoxShadowParts = global.hpe.focusIndicator.boxShadow
+    .trim()
+    .split(' ');
+
   return deepFreeze({
     defaultMode: 'light',
     global: {
@@ -831,8 +835,8 @@ const buildTheme = (tokens, flags) => {
           offset: global.hpe.focusIndicator.outlineOffset,
         },
         shadow: {
-          color: global.hpe.focusIndicator.boxShadow.color,
-          size: global.hpe.focusIndicator.boxShadow.spread,
+          color: focusBoxShadowParts[focusBoxShadowParts.length - 1],
+          size: focusBoxShadowParts[focusBoxShadowParts.length - 2],
           blur: '0px',
         },
         twoColor: true,
@@ -844,7 +848,7 @@ const buildTheme = (tokens, flags) => {
             offset: `-${global.hpe.focusIndicator.outline.width}`,
           },
           shadow: {
-            color: global.hpe.focusIndicator.boxShadow.color,
+            color: focusBoxShadowParts[focusBoxShadowParts.length - 1],
             size: '4px',
             blur: '0px',
             inset: true,


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
In this tokens PR https://github.com/grommet/hpe-design-system/pull/5668 the following code was removed which results in the focus boxShadow token format changing to a string format instead of an object.

```
  // Temporary fix for focusIndicator box shadow in grommet theme
  if (token.$type === 'shadow' && token.name.includes('focusIndicator')) {
    result = token.original.$value[0];
  }
```

This PR relies on https://github.com/grommet/hpe-design-system/pull/5668 being merged an a tokens patch release being published. As part of this change the tokens dependency should be bumped to the latest version after the release is published.

#### What testing has been done on this PR?

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
