### PR TITLE
changed button from default to secondary

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1797,10 +1797,10 @@ const buildTheme = (tokens, flags) => {
       },
       button: {
         background: components.hpe.button.secondary.rest.background,
-        border: { radius: components.hpe.button.default.medium.borderRadius },
+        border: { radius: components.hpe.button.secondary.medium.borderRadius },
         pad: {
-          vertical: components.hpe.button.default.medium.paddingY,
-          horizontal: components.hpe.button.default.medium.paddingX,
+          vertical: components.hpe.button.secondary.medium.paddingY,
+          horizontal: components.hpe.button.secondary.medium.paddingX,
         },
         color: components.hpe.button.secondary.rest.textColor,
         font: { weight: components.hpe.button.secondary.rest.fontWeight },


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes an incorrect token reference in the secondary Button theme configuration by updating border.radius and pad to use secondary button tokens instead of default button tokens. This ensures variant-specific sizing and styling are correctly sourced from the design system.

#### What testing has been done on this PR?
Verified secondary Button rendering in a local Grommet setup.



#### Any background context you want to provide?
Nothing

#### What are the relevant issues?
Nothing

#### Screenshots (if appropriate)
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/143b0c6d-893e-4ffb-a934-5056a5f39e29" />

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

This change is backward compatible. It corrects token references without altering computed styles and improves future compatibility with evolving design tokens.

#### How should this PR be communicated in the release notes?
   Patch fix
      Fixed secondary Button to reference correct variant-specific sizing tokens instead of default button tokens.(#579)
