### PR TITLE
derive the font family name for the face from the family list token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ yarn-error.log
 coverage
 dist
 .DS_Store
+.yalc

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -579,6 +579,15 @@ const buildTheme = (tokens, flags) => {
   const backgroundDeprecationMessage = (background) =>
     `The background "${background}" is deprecated and will be removed in v9 to ensure access to the latest Brand assets. Please replace this key by referencing an image URL directly. You can find approved backgrounds within HPE Brand Central (https://brandcentral.hpe.com/brand-central/content/imagery).`;
 
+  // Figure out what name is being used for the Graphik font in the family list.
+  // Since we're going to map the font-faces to Graphik font files we specifically
+  // look for something containing "Graphik"
+  const family =
+    global.hpe.fontStack.primary
+      .split(',')
+      .map((s) => s.trim().replace(/['"]/g, ''))
+      .find((f) => f.includes('Graphik')) || 'HPE Graphik';
+
   return deepFreeze({
     defaultMode: 'light',
     global: {
@@ -742,31 +751,31 @@ const buildTheme = (tokens, flags) => {
         family: global.hpe.fontStack.primary,
         face: `
           @font-face {
-            font-family: "Graphik";
+            font-family: "${family}";
             src: url("https://www.hpe.com/content/dam/hpe/fonts/graphik/HPEGraphik-Regular-Web.woff2") format('woff2');
           }
           @font-face {
-            font-family: "Graphik";
+            font-family: "${family}";
             src: url("https://www.hpe.com/content/dam/hpe/fonts/graphik/HPEGraphik-Regular-Web.woff2") format('woff2');
             font-weight: 400;
           }
           @font-face {
-            font-family: "Graphik";
+            font-family: "${family}";
             src: url("https://www.hpe.com/content/dam/hpe/fonts/graphik/HPEGraphik-Bold-Web.woff2") format('woff2');
             font-weight: 700;
           }
           @font-face {
-            font-family: "Graphik";
+            font-family: "${family}";
             src: url("https://www.hpe.com/content/dam/hpe/fonts/graphik/HPEGraphik-Semibold-Web.woff2") format('woff2');
             font-weight: 600;
           }
           @font-face {
-            font-family: "Graphik";
+            font-family: "${family}";
             src: url("https://www.hpe.com/content/dam/hpe/fonts/graphik/HPEGraphik-Medium-Web.woff2") format('woff2');
             font-weight: 500;
           }
           @font-face {
-            font-family: "Graphik";
+            font-family: "${family}";
             src: url("https://www.hpe.com/content/dam/hpe/fonts/graphik/HPEGraphik-Extralight-Web.woff2") format('woff2');
             font-weight: 100;
           }


### PR DESCRIPTION
#### What does this PR do?
In the 8.1 version of the theme, the font family list token changed from `Graphik, Arial, sans-serif` to `'HPE Graphik', Arial, sans-serif`, however the `@font-face` definitions in the theme were still just specifying just `Graphik`. The result is it wasn't correctly mapping the fonts to the font files being loaded from the CDN.

Most of us didn't notice the issue because we have HPE Graphik fonts installed on our dev computers. The browser was able to simply find those fonts by the `HPE Graphik` name on our local machines.

Customer client systems generally wouldn't have that font installed and therefore wouldn't display the correct font.

This change tries to extract the family name from the font family list from the design token. Since we're going to map that name to one of the HPE Graphik font files from the CDN, we at least look for a name containing `Graphik` (and default to the expected `HPE Graphik` if we didn't find one in the list. The result is if the font family token has something like `Graphik, Arial, sans-serif` we map the font files to `Graphik`. But if the token instead has `'HPE Graphik', Arial, sans-serif` we map the font files to `HPE Graphik` as we would currently expect.

This PR also adds yalc to the `.gitignore` since I'm tired of doing it locally :)

#### What testing has been done on this PR?
Test react app using the 8.1.1 theme (with the above modification.)

#### Any background context you want to provide?

#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
compatible

#### How should this PR be communicated in the release notes?
Fixed the mapping of the HPE Graphik family to the correct font-faces from the CDN.