### PR TITLE
fix the calendar text color

### DIFF
--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1316,7 +1316,7 @@ const buildTheme = (tokens, flags) => {
             if (toggle) {
               borderColor = getThemeColor(
                 components.hpe.switch.default.control.track.selected.hover
-                  .borderColxor,
+                  .borderColor,
                 theme,
               );
             } else {

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -1178,12 +1178,14 @@ const buildTheme = (tokens, flags) => {
           font: { weight: global.hpe.fontWeight.medium },
         },
         extend: ({ isSelected, theme }) =>
-          // grommet logic was incorrectly switching to wrong theme mode
-          // so overriding in extend
+          // The "text-onSelectedPrimaryStrong" token has its light/dark values
+          // intentionally swapped (see colors.js swapped()). Invert theme.dark
+          // here to "un-swap" and resolve the correct color, matching the
+          // same pattern used for the checkbox checkmark (PR #573).
           isSelected
             ? `color: ${
                 theme.global.colors['text-onSelectedPrimaryStrong'][
-                  theme.dark ? 'dark' : 'light'
+                  theme.dark ? 'light' : 'dark'
                 ]
               };`
             : '',
@@ -1314,7 +1316,7 @@ const buildTheme = (tokens, flags) => {
             if (toggle) {
               borderColor = getThemeColor(
                 components.hpe.switch.default.control.track.selected.hover
-                  .borderColor,
+                  .borderColxor,
                 theme,
               );
             } else {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR fixes the text color in the DateInput 

<img width="919" height="570" alt="Screenshot 2026-05-20 at 10 55 00 AM" src="https://github.com/user-attachments/assets/e918a38e-fd47-4950-b2e9-2869cb920106" />

#### What testing has been done on this PR?
testing was done with `yalc` in grommet

<img width="1420" height="674" alt="Screenshot 2026-05-20 at 10 55 25 AM" src="https://github.com/user-attachments/assets/61c434eb-6948-4d48-90ab-a9244be32a40" />

<img width="1309" height="626" alt="Screenshot 2026-05-20 at 10 57 21 AM" src="https://github.com/user-attachments/assets/19e81afd-d3bb-43e8-8d07-16e318116d0b" />


#### Any background context you want to provide?
PR #563 intentionally stored `text-onSelectedPrimaryStrong` (and related tokens) with swapped `light``dark` keys to work around a grommet color-resolution bug (#7818). The calendar's `day.extend` predated that change and was written assuming non-swapped token keys. The same issue was previously fixed for the checkbox checkmark icon in PR #573.
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
Yes 
#### How should this PR be communicated in the release notes?
DateInput selected date text color now displays correctly in both light and dark modes.