### PR TITLE
Added support building colors from provided tokens, not just imports from published package

### DIFF
--- a/src/js/__tests__/unit/colors.test.js
+++ b/src/js/__tests__/unit/colors.test.js
@@ -1,0 +1,41 @@
+import {
+  primitives as localPrimitives,
+  dark as localDark,
+  light as localLight,
+  components as localComponents,
+} from 'hpe-design-tokens/grommet';
+import { buildColors, colors } from '../../themes/colors';
+
+describe('color builder', () => {
+  const tokens = {
+    primitives: localPrimitives,
+    light: localLight,
+    dark: localDark,
+    components: localComponents,
+  };
+
+  it('builds the canonical colors map from tokens', () => {
+    expect(buildColors(tokens)).toEqual(colors);
+  });
+
+  it('responds to token changes instead of using a precomputed import', () => {
+    const customTokens = {
+      ...tokens,
+      light: {
+        ...localLight,
+        hpe: {
+          ...localLight.hpe,
+          color: {
+            ...localLight.hpe.color,
+            text: {
+              ...localLight.hpe.color.text,
+              default: '#123456',
+            },
+          },
+        },
+      },
+    };
+
+    expect(buildColors(customTokens).text.light).toBe('#123456');
+  });
+});

--- a/src/js/__tests__/unit/prism.test.js
+++ b/src/js/__tests__/unit/prism.test.js
@@ -1,0 +1,47 @@
+import {
+  primitives as localPrimitives,
+  dark as localDark,
+  light as localLight,
+  components as localComponents,
+} from 'hpe-design-tokens/grommet';
+import { buildPrism, prism } from '../../themes/prism';
+import { buildColors } from '../../themes/colors';
+
+describe('prism builder', () => {
+  const tokens = {
+    primitives: localPrimitives,
+    light: localLight,
+    dark: localDark,
+    components: localComponents,
+  };
+
+  it('builds the canonical prism theme from tokens', () => {
+    expect(buildPrism(tokens)).toEqual(prism);
+  });
+
+  it('responds to token changes instead of using a precomputed import', () => {
+    const customTokens = {
+      ...tokens,
+      light: {
+        ...localLight,
+        hpe: {
+          ...localLight.hpe,
+          color: {
+            ...localLight.hpe.color,
+            text: {
+              ...localLight.hpe.color.text,
+              default: '#123456',
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      buildPrism(customTokens).light['code[class*="language-"]'].color,
+    ).toBe('#123456');
+    expect(
+      buildPrism(customTokens).light['pre[class*="language-"]'].background,
+    ).toBe(buildColors(customTokens)['background-contrast'].light);
+  });
+});

--- a/src/js/themes/colors.js
+++ b/src/js/themes/colors.js
@@ -1,4 +1,9 @@
-import { primitives, dark, light, components } from 'hpe-design-tokens/grommet';
+import {
+  primitives as localPrimitives,
+  dark as localDark,
+  light as localLight,
+  components as localComponents,
+} from 'hpe-design-tokens/grommet';
 
 const flattenObject = (obj, delimiter = '.', prefix = '') =>
   Object.keys(obj).reduce((acc, k) => {
@@ -24,9 +29,9 @@ const flattenObject = (obj, delimiter = '.', prefix = '') =>
 // Utility to access nested object properties via dot-notation string path
 // and swap light/dark theme values.
 const access = (path, object) => path.split('.').reduce((o, i) => o[i], object);
-const swapped = (path) => {
-  const lightValue = access(`${path}`, dark);
-  const darkValue = access(`${path}`, light);
+const swapped = (path, darkTheme, lightTheme) => {
+  const lightValue = access(`${path}`, darkTheme);
+  const darkValue = access(`${path}`, lightTheme);
 
   return {
     light: lightValue,
@@ -34,181 +39,209 @@ const swapped = (path) => {
   };
 };
 
-const flatColors = flattenObject(light, '-');
-const tokenColors = {};
-Object.keys(flatColors).forEach((color) => {
-  if (!color.includes('shadow')) {
-    if (color === 'focus-support') {
-      // special case for 'focus-support' because it follows a different
-      // naming pattern than other token colors. The change ensures that
-      // focus-support is correctly added to the colors array
-      tokenColors[color] = {
-        light: light.hpe.color['focus-support'],
-        dark: dark.hpe.color['focus-support'],
-      };
-    } else {
-      const [category] = color.split('-');
-      const flatName = color.split('-').slice(1).join('-');
-      tokenColors[color] = {
-        light: access(
-          `hpe.color.${category}${flatName ? `.${flatName}` : ''}`,
-          light,
-        ),
-        dark: access(
-          `hpe.color.${category}${flatName ? `.${flatName}` : ''}`,
-          dark,
-        ),
-      };
+export const buildColors = (tokens) => {
+  const { primitives, dark, light, components } = tokens;
+
+  const flatColors = flattenObject(light, '-');
+  const tokenColors = {};
+  Object.keys(flatColors).forEach((color) => {
+    if (!color.includes('shadow')) {
+      if (color === 'focus-support') {
+        // special case for 'focus-support' because it follows a different
+        // naming pattern than other token colors. The change ensures that
+        // focus-support is correctly added to the colors array
+        tokenColors[color] = {
+          light: light.hpe.color['focus-support'],
+          dark: dark.hpe.color['focus-support'],
+        };
+      } else {
+        const [category] = color.split('-');
+        const flatName = color.split('-').slice(1).join('-');
+        tokenColors[color] = {
+          light: access(
+            `hpe.color.${category}${flatName ? `.${flatName}` : ''}`,
+            light,
+          ),
+          dark: access(
+            `hpe.color.${category}${flatName ? `.${flatName}` : ''}`,
+            dark,
+          ),
+        };
+      }
     }
-  }
-});
-export const colors = {
-  // Here we're passing through all the colors from hpe-design-tokens
-  ...tokenColors,
-  // Override specific colors to swap light and dark.hpe values
-  // See https://github.com/grommet/grommet/issues/7818
-  'text-onPrimaryStrong': swapped('hpe.color.text.onPrimaryStrong'),
-  'text-onSelectedPrimaryStrong': swapped(
-    'hpe.color.text.onSelectedPrimaryStrong',
-  ),
-  'icon-onPrimaryStrong': swapped('hpe.color.icon.onPrimaryStrong'),
-  'icon-onSelectedPrimaryStrong': swapped(
-    'hpe.color.icon.onSelectedPrimaryStrong',
-  ),
-  control: 'background-primary-strong',
-  'active-text': 'text-strong',
-  'text-primary-button': components.hpe.button.primary.rest.textColor,
-  brand: {
-    dark: dark.hpe.color.decorative.brand,
-    light: light.hpe.color.decorative.brand,
-  },
-  'background-layer-overlay': {
-    dark: dark.hpe.color.background.screenOverlay,
-    light: light.hpe.color.background.screenOverlay,
-  },
-  'active-background': {
-    dark: dark.hpe.color.background.active,
-    light: light.hpe.color.background.active,
-  },
-  background: {
-    dark: dark.hpe.color.background.default,
-    light: light.hpe.color.background.default,
-  },
-  text: {
-    dark: dark.hpe.color.text.default,
-    light: light.hpe.color.text.default,
-  },
-  // wanted to deprecate text-xweak but namespace is used
-  // in grommet code
-  'text-xweak': {
-    dark: dark.hpe.color.text.weak,
-    light: light.hpe.color.text.weak,
-  },
-  border: {
-    dark: dark.hpe.color.border.default,
-    light: light.hpe.color.border.default,
-  },
-  blue: {
-    dark: dark.hpe.color.decorative.blue,
-    light: light.hpe.color.decorative.blue,
-  },
-  'blue!': primitives.hpe.base.color['blue-700'],
-  green: {
-    dark: dark.hpe.color.decorative.green,
-    light: light.hpe.color.decorative.green,
-  },
-  'green!': {
-    dark: dark.hpe.color.decorative.brand,
-    light: light.hpe.color.decorative.brand,
-  },
-  purple: {
-    dark: dark.hpe.color.decorative.purple,
-    light: light.hpe.color.decorative.purple,
-  },
-  'purple!': '#7630EA',
-  'status-critical': {
-    dark: dark.hpe.color.icon.critical,
-    light: light.hpe.color.icon.critical,
-  },
-  'status-warning': {
-    dark: dark.hpe.color.icon.warning,
-    light: light.hpe.color.icon.warning,
-  },
-  'status-ok': { dark: dark.hpe.color.icon.ok, light: light.hpe.color.icon.ok },
-  'status-unknown': {
-    dark: dark.hpe.color.icon.unknown,
-    light: light.hpe.color.icon.unknown,
-  },
-  'validation-critical': {
-    light: light.hpe.color.background.critical,
-    dark: dark.hpe.color.background.critical,
-  },
-  'validation-ok': {
-    light: light.hpe.color.background.ok,
-    dark: dark.hpe.color.background.ok,
-  },
-  'validation-warning': {
-    light: light.hpe.color.background.warning,
-    dark: dark.hpe.color.background.warning,
-  },
-  icon: {
-    light: light.hpe.color.icon.default,
-    dark: dark.hpe.color.icon.default,
-  },
-  'selected-background': 'background-selected-strong-enabled',
-  'selected-text': 'text-onSelectedPrimaryStrong',
-  placeholder: {
-    light: light.hpe.color.text.placeholder,
-    dark: dark.hpe.color.text.placeholder,
-  },
-  // ---- DEPRECATED ---- //
-  // Need to keep these deprecated keys (using undefined or aliases)
-  // to avoid falling back to Grommet defaults
-  'accent-1': undefined,
-  'accent-2': undefined,
-  'accent-3': undefined,
-  'accent-4': undefined,
-  'neutral-1': undefined,
-  'neutral-2': undefined,
-  'neutral-3': undefined,
-  'neutral-4': undefined,
-  'neutral-5': undefined,
-  'status-error': undefined,
-  'background-cta-alternate': 'background-contrast',
-  'disabled-text': 'text-disabled',
-  // In v10 change graph colors to undefined to avoid falling back to Grommet defaults
-  'graph-0': {
-    light: light.hpe.color.dataVis['categorical-10'],
-    dark: dark.hpe.color.dataVis['categorical-10'],
-  },
-  'graph-1': {
-    light: light.hpe.color.dataVis['categorical-20'],
-    dark: dark.hpe.color.dataVis['categorical-20'],
-  },
-  'graph-2': {
-    light: light.hpe.color.dataVis['categorical-30'],
-    dark: dark.hpe.color.dataVis['categorical-30'],
-  },
-  'graph-3': {
-    light: light.hpe.color.dataVis['categorical-40'],
-    dark: dark.hpe.color.dataVis['categorical-40'],
-  },
-  'graph-4': {
-    light: light.hpe.color.dataVis['categorical-50'],
-    dark: dark.hpe.color.dataVis['categorical-50'],
-  },
-  'graph-5': {
-    light: light.hpe.color.dataVis['categorical-60'],
-    dark: dark.hpe.color.dataVis['categorical-60'],
-  },
-  'graph-6': {
-    light: light.hpe.color.dataVis['categorical-70'],
-    dark: dark.hpe.color.dataVis['categorical-70'],
-  },
-  'graph-7': {
-    light: light.hpe.color.dataVis['categorical-80'],
-    dark: dark.hpe.color.dataVis['categorical-80'],
-  },
-  'status-disabled': '#CCCCCC', // deprecated, does not support light and dark.hpe. use text-weak instead
-  // -------------------- //
+  });
+
+  return {
+    // Here we're passing through all the colors from hpe-design-tokens
+    ...tokenColors,
+    // Override specific colors to swap light and dark.hpe values
+    // See https://github.com/grommet/grommet/issues/7818
+    'text-onPrimaryStrong': swapped(
+      'hpe.color.text.onPrimaryStrong',
+      dark,
+      light,
+    ),
+    'text-onSelectedPrimaryStrong': swapped(
+      'hpe.color.text.onSelectedPrimaryStrong',
+      dark,
+      light,
+    ),
+    'icon-onPrimaryStrong': swapped(
+      'hpe.color.icon.onPrimaryStrong',
+      dark,
+      light,
+    ),
+    'icon-onSelectedPrimaryStrong': swapped(
+      'hpe.color.icon.onSelectedPrimaryStrong',
+      dark,
+      light,
+    ),
+    control: 'background-primary-strong',
+    'active-text': 'text-strong',
+    'text-primary-button': components.hpe.button.primary.rest.textColor,
+    brand: {
+      dark: dark.hpe.color.decorative.brand,
+      light: light.hpe.color.decorative.brand,
+    },
+    'background-layer-overlay': {
+      dark: dark.hpe.color.background.screenOverlay,
+      light: light.hpe.color.background.screenOverlay,
+    },
+    'active-background': {
+      dark: dark.hpe.color.background.active,
+      light: light.hpe.color.background.active,
+    },
+    background: {
+      dark: dark.hpe.color.background.default,
+      light: light.hpe.color.background.default,
+    },
+    text: {
+      dark: dark.hpe.color.text.default,
+      light: light.hpe.color.text.default,
+    },
+    // wanted to deprecate text-xweak but namespace is used
+    // in grommet code
+    'text-xweak': {
+      dark: dark.hpe.color.text.weak,
+      light: light.hpe.color.text.weak,
+    },
+    border: {
+      dark: dark.hpe.color.border.default,
+      light: light.hpe.color.border.default,
+    },
+    blue: {
+      dark: dark.hpe.color.decorative.blue,
+      light: light.hpe.color.decorative.blue,
+    },
+    'blue!': primitives.hpe.base.color['blue-700'],
+    green: {
+      dark: dark.hpe.color.decorative.green,
+      light: light.hpe.color.decorative.green,
+    },
+    'green!': {
+      dark: dark.hpe.color.decorative.brand,
+      light: light.hpe.color.decorative.brand,
+    },
+    purple: {
+      dark: dark.hpe.color.decorative.purple,
+      light: light.hpe.color.decorative.purple,
+    },
+    'purple!': '#7630EA',
+    'status-critical': {
+      dark: dark.hpe.color.icon.critical,
+      light: light.hpe.color.icon.critical,
+    },
+    'status-warning': {
+      dark: dark.hpe.color.icon.warning,
+      light: light.hpe.color.icon.warning,
+    },
+    'status-ok': {
+      dark: dark.hpe.color.icon.ok,
+      light: light.hpe.color.icon.ok,
+    },
+    'status-unknown': {
+      dark: dark.hpe.color.icon.unknown,
+      light: light.hpe.color.icon.unknown,
+    },
+    'validation-critical': {
+      light: light.hpe.color.background.critical,
+      dark: dark.hpe.color.background.critical,
+    },
+    'validation-ok': {
+      light: light.hpe.color.background.ok,
+      dark: dark.hpe.color.background.ok,
+    },
+    'validation-warning': {
+      light: light.hpe.color.background.warning,
+      dark: dark.hpe.color.background.warning,
+    },
+    icon: {
+      light: light.hpe.color.icon.default,
+      dark: dark.hpe.color.icon.default,
+    },
+    'selected-background': 'background-selected-strong-enabled',
+    'selected-text': 'text-onSelectedPrimaryStrong',
+    placeholder: {
+      light: light.hpe.color.text.placeholder,
+      dark: dark.hpe.color.text.placeholder,
+    },
+    // ---- DEPRECATED ---- //
+    // Need to keep these deprecated keys (using undefined or aliases)
+    // to avoid falling back to Grommet defaults
+    'accent-1': undefined,
+    'accent-2': undefined,
+    'accent-3': undefined,
+    'accent-4': undefined,
+    'neutral-1': undefined,
+    'neutral-2': undefined,
+    'neutral-3': undefined,
+    'neutral-4': undefined,
+    'neutral-5': undefined,
+    'status-error': undefined,
+    'background-cta-alternate': 'background-contrast',
+    'disabled-text': 'text-disabled',
+    // In v10 change graph colors to undefined to avoid falling back to Grommet defaults
+    'graph-0': {
+      light: light.hpe.color.dataVis['categorical-10'],
+      dark: dark.hpe.color.dataVis['categorical-10'],
+    },
+    'graph-1': {
+      light: light.hpe.color.dataVis['categorical-20'],
+      dark: dark.hpe.color.dataVis['categorical-20'],
+    },
+    'graph-2': {
+      light: light.hpe.color.dataVis['categorical-30'],
+      dark: dark.hpe.color.dataVis['categorical-30'],
+    },
+    'graph-3': {
+      light: light.hpe.color.dataVis['categorical-40'],
+      dark: dark.hpe.color.dataVis['categorical-40'],
+    },
+    'graph-4': {
+      light: light.hpe.color.dataVis['categorical-50'],
+      dark: dark.hpe.color.dataVis['categorical-50'],
+    },
+    'graph-5': {
+      light: light.hpe.color.dataVis['categorical-60'],
+      dark: dark.hpe.color.dataVis['categorical-60'],
+    },
+    'graph-6': {
+      light: light.hpe.color.dataVis['categorical-70'],
+      dark: dark.hpe.color.dataVis['categorical-70'],
+    },
+    'graph-7': {
+      light: light.hpe.color.dataVis['categorical-80'],
+      dark: dark.hpe.color.dataVis['categorical-80'],
+    },
+    'status-disabled': '#CCCCCC', // deprecated, does not support light and dark.hpe. use text-weak instead
+    // -------------------- //
+  };
 };
+
+// Preserve the public prebuilt colors export using the package default tokens.
+export const colors = buildColors({
+  primitives: localPrimitives,
+  dark: localDark,
+  light: localLight,
+  components: localComponents,
+});

--- a/src/js/themes/hpe.js
+++ b/src/js/themes/hpe.js
@@ -46,7 +46,6 @@ import { StatusCritical } from '@hpe-design/icons-grommet/icons/StatusCritical';
 import { baseSpacing, deepFreeze, getThemeColor } from './utils';
 
 import { backgrounds } from './backgrounds';
-import { colors } from './colors';
 import { buildDimensions } from './dimensions';
 import { buildTypography } from './typography';
 import { buildButtonTheme } from './button';
@@ -60,9 +59,11 @@ import { buildLayoutTheme } from './layout';
 import { buildDeprecations } from './deprecations';
 import { getGraphikFamily, getGraphikFontFaces } from './fonts';
 import { buildGlobalTheme } from './global';
+import { buildColors } from './colors';
 
 const buildTheme = (tokens, flags) => {
   const { light, dark, global, components } = tokens;
+  const colors = buildColors(tokens);
 
   const dimensions = buildDimensions(tokens, flags);
 

--- a/src/js/themes/index.js
+++ b/src/js/themes/index.js
@@ -3,5 +3,5 @@
 export { hpe } from './hpe';
 export * from './hpePop';
 export * from './backgrounds';
-export * from './colors';
+export { colors } from './colors';
 export * from './prism';

--- a/src/js/themes/index.js
+++ b/src/js/themes/index.js
@@ -4,4 +4,4 @@ export { hpe } from './hpe';
 export * from './hpePop';
 export * from './backgrounds';
 export { colors } from './colors';
-export * from './prism';
+export { prism } from './prism';

--- a/src/js/themes/prism.js
+++ b/src/js/themes/prism.js
@@ -1,115 +1,128 @@
 // Theme for code syntax highlighting
 // Exported theme object is consumed by ReactSyntaxHighlighter + PrismJS
 // https://github.com/react-syntax-highlighter/react-syntax-highlighter#prism
-import { primitives, dark, light } from 'hpe-design-tokens/grommet';
-import { colors as hpeColors } from './colors';
+import {
+  primitives as localPrimitives,
+  dark as localDark,
+  light as localLight,
+  components as localComponents,
+} from 'hpe-design-tokens/grommet';
+import { buildColors } from './colors';
 
-const colors = {
-  atrule: {
-    dark: primitives.hpe.base.color['fuschia-200'],
-    light: primitives.hpe.base.color['fuschia-700'],
-  },
-  'attr-name': {
-    dark: primitives.hpe.base.color['plum-100'],
-    light: primitives.hpe.base.color['plum-600'],
-  },
-  'attr-value': {
-    dark: primitives.hpe.base.color['fuschia-200'],
-    light: primitives.hpe.base.color['fuschia-700'],
-  },
-  background: { dark: 'black', light: hpeColors['background-contrast'].light },
-  boolean: {
-    dark: primitives.hpe.base.color['plum-100'],
-    light: primitives.hpe.base.color['plum-600'],
-  },
-  'class-name': {
-    dark: primitives.hpe.base.color['coral-200'],
-    light: primitives.hpe.base.color['coral-500'],
-  },
-  builtin: {
-    dark: primitives.hpe.base.color['plum-100'],
-    light: primitives.hpe.base.color['plum-600'],
-  },
-  char: {
-    dark: primitives.hpe.base.color['plum-100'],
-    light: primitives.hpe.base.color['plum-600'],
-  },
-  code: {
-    dark: dark.hpe.color.text.default,
-    light: light.hpe.color.text.default,
-  },
-  comment: {
-    dark: primitives.hpe.base.color['green-550'],
-    light: primitives.hpe.base.color['green-800'],
-  },
-  entity: {
-    dark: primitives.hpe.base.color['blue-200'],
-    light: primitives.hpe.base.color['blue-700'],
-  },
-  function: {
-    dark: primitives.hpe.base.color['coral-200'],
-    light: primitives.hpe.base.color['coral-500'],
-  },
-  important: {
-    dark: primitives.hpe.base.color['fuschia-200'],
-    light: primitives.hpe.base.color['fuschia-700'],
-  },
-  inserted: {
-    dark: primitives.hpe.base.color['plum-100'],
-    light: primitives.hpe.base.color['plum-600'],
-  },
-  keyword: {
-    dark: primitives.hpe.base.color['blue-200'],
-    light: primitives.hpe.base.color['blue-700'],
-  },
-  'maybe-class-name': {
-    dark: primitives.hpe.base.color['purple-200'],
-    light: primitives.hpe.base.color['purple-700'],
-  },
-  number: {
-    dark: primitives.hpe.base.color['plum-100'],
-    light: primitives.hpe.base.color['plum-600'],
-  },
-  operator: {
-    dark: primitives.hpe.base.color['fuschia-200'],
-    light: primitives.hpe.base.color['fuschia-700'],
-  },
-  regex: {
-    dark: primitives.hpe.base.color['fuschia-200'],
-    light: primitives.hpe.base.color['fuschia-700'],
-  },
-  selector: {
-    dark: primitives.hpe.base.color['plum-100'],
-    light: primitives.hpe.base.color['plum-600'],
-  },
-  string: {
-    dark: primitives.hpe.base.color['plum-100'],
-    light: primitives.hpe.base.color['plum-600'],
-  },
-  url: {
-    dark: primitives.hpe.base.color['blue-200'],
-    light: primitives.hpe.base.color['blue-700'],
-  },
-  variable: {
-    dark: primitives.hpe.base.color['blue-200'],
-    light: primitives.hpe.base.color['blue-700'],
-  },
-  '.language-css .token.string': {
-    dark: primitives.hpe.base.color['blue-200'],
-    light: primitives.hpe.base.color['blue-700'],
-  },
-  '.style .token.string': {
-    dark: primitives.hpe.base.color['blue-200'],
-    light: primitives.hpe.base.color['blue-700'],
-  },
+const createPrismColors = (tokens) => {
+  const { primitives, dark, light } = tokens;
+  const hpeColors = buildColors(tokens);
+
+  return {
+    atrule: {
+      dark: primitives.hpe.base.color['fuschia-200'],
+      light: primitives.hpe.base.color['fuschia-700'],
+    },
+    'attr-name': {
+      dark: primitives.hpe.base.color['plum-100'],
+      light: primitives.hpe.base.color['plum-600'],
+    },
+    'attr-value': {
+      dark: primitives.hpe.base.color['fuschia-200'],
+      light: primitives.hpe.base.color['fuschia-700'],
+    },
+    background: {
+      dark: 'black',
+      light: hpeColors['background-contrast'].light,
+    },
+    boolean: {
+      dark: primitives.hpe.base.color['plum-100'],
+      light: primitives.hpe.base.color['plum-600'],
+    },
+    'class-name': {
+      dark: primitives.hpe.base.color['coral-200'],
+      light: primitives.hpe.base.color['coral-500'],
+    },
+    builtin: {
+      dark: primitives.hpe.base.color['plum-100'],
+      light: primitives.hpe.base.color['plum-600'],
+    },
+    char: {
+      dark: primitives.hpe.base.color['plum-100'],
+      light: primitives.hpe.base.color['plum-600'],
+    },
+    code: {
+      dark: dark.hpe.color.text.default,
+      light: light.hpe.color.text.default,
+    },
+    comment: {
+      dark: primitives.hpe.base.color['green-550'],
+      light: primitives.hpe.base.color['green-800'],
+    },
+    entity: {
+      dark: primitives.hpe.base.color['blue-200'],
+      light: primitives.hpe.base.color['blue-700'],
+    },
+    function: {
+      dark: primitives.hpe.base.color['coral-200'],
+      light: primitives.hpe.base.color['coral-500'],
+    },
+    important: {
+      dark: primitives.hpe.base.color['fuschia-200'],
+      light: primitives.hpe.base.color['fuschia-700'],
+    },
+    inserted: {
+      dark: primitives.hpe.base.color['plum-100'],
+      light: primitives.hpe.base.color['plum-600'],
+    },
+    keyword: {
+      dark: primitives.hpe.base.color['blue-200'],
+      light: primitives.hpe.base.color['blue-700'],
+    },
+    'maybe-class-name': {
+      dark: primitives.hpe.base.color['purple-200'],
+      light: primitives.hpe.base.color['purple-700'],
+    },
+    number: {
+      dark: primitives.hpe.base.color['plum-100'],
+      light: primitives.hpe.base.color['plum-600'],
+    },
+    operator: {
+      dark: primitives.hpe.base.color['fuschia-200'],
+      light: primitives.hpe.base.color['fuschia-700'],
+    },
+    regex: {
+      dark: primitives.hpe.base.color['fuschia-200'],
+      light: primitives.hpe.base.color['fuschia-700'],
+    },
+    selector: {
+      dark: primitives.hpe.base.color['plum-100'],
+      light: primitives.hpe.base.color['plum-600'],
+    },
+    string: {
+      dark: primitives.hpe.base.color['plum-100'],
+      light: primitives.hpe.base.color['plum-600'],
+    },
+    url: {
+      dark: primitives.hpe.base.color['blue-200'],
+      light: primitives.hpe.base.color['blue-700'],
+    },
+    variable: {
+      dark: primitives.hpe.base.color['blue-200'],
+      light: primitives.hpe.base.color['blue-700'],
+    },
+    '.language-css .token.string': {
+      dark: primitives.hpe.base.color['blue-200'],
+      light: primitives.hpe.base.color['blue-700'],
+    },
+    '.style .token.string': {
+      dark: primitives.hpe.base.color['blue-200'],
+      light: primitives.hpe.base.color['blue-700'],
+    },
+  };
 };
 
 // PrismJs + ReactSyntaxHighlighter implementation references:
 // https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/src/styles/prism/a11y-dark.js
 // Prism selectors: https://github.com/PrismJS/prism/blob/master/themes/prism.css
-const themeMode = (mode) => ({
+const themeMode = (mode, prismColors) => ({
   'code[class*="language-"]': {
-    color: colors.code[mode],
+    color: prismColors.code[mode],
     background: 'none',
     fontFamily: "'Fira Mono', monospace",
     textAlign: 'left',
@@ -127,8 +140,8 @@ const themeMode = (mode) => ({
     hyphens: 'none',
   },
   'pre[class*="language-"]': {
-    color: colors.code[mode],
-    background: colors.background[mode],
+    color: prismColors.code[mode],
+    background: prismColors.background[mode],
     fontFamily: "'Fira Mono', monospace",
     textAlign: 'left',
     whiteSpace: 'pre',
@@ -149,38 +162,52 @@ const themeMode = (mode) => ({
     borderRadius: '0.3em',
   },
   ':not(pre) > code[class*="language-"]': {
-    background: colors.background[mode],
+    background: prismColors.background[mode],
     padding: '0.1em',
     borderRadius: '0.3em',
     whiteSpace: 'normal',
   },
-  'class-name': { color: colors['class-name'][mode] },
-  'maybe-class-name': { color: colors['maybe-class-name'][mode] },
-  comment: { color: colors.comment[mode] },
-  function: { color: colors.function[mode] },
-  operator: { color: colors.operator[mode] },
-  string: { color: colors.string[mode] },
-  boolean: { color: colors.boolean[mode] },
-  number: { color: colors.number[mode] },
-  keyword: { color: colors.keyword[mode] },
-  selector: { color: colors.selector[mode] },
-  'attr-name': { color: colors['attr-name'][mode] },
-  char: { color: colors.char[mode] },
-  builtin: { color: colors.builtin[mode] },
-  inserted: { color: colors.inserted[mode] },
-  entity: { color: colors.entity[mode], cursor: 'help' },
-  url: { color: colors.url[mode] },
+  'class-name': { color: prismColors['class-name'][mode] },
+  'maybe-class-name': { color: prismColors['maybe-class-name'][mode] },
+  comment: { color: prismColors.comment[mode] },
+  function: { color: prismColors.function[mode] },
+  operator: { color: prismColors.operator[mode] },
+  string: { color: prismColors.string[mode] },
+  boolean: { color: prismColors.boolean[mode] },
+  number: { color: prismColors.number[mode] },
+  keyword: { color: prismColors.keyword[mode] },
+  selector: { color: prismColors.selector[mode] },
+  'attr-name': { color: prismColors['attr-name'][mode] },
+  char: { color: prismColors.char[mode] },
+  builtin: { color: prismColors.builtin[mode] },
+  inserted: { color: prismColors.inserted[mode] },
+  entity: { color: prismColors.entity[mode], cursor: 'help' },
+  url: { color: prismColors.url[mode] },
   '.language-css .token.string': {
-    color: colors['.language-css .token.string'][mode],
+    color: prismColors['.language-css .token.string'][mode],
   },
-  '.style .token.string': { color: colors['.style .token.string'][mode] },
-  variable: { color: colors.variable[mode] },
-  atrule: { color: colors.atrule[mode] },
-  'attr-value': { color: colors['attr-value'][mode] },
-  regex: { color: colors.regex[mode] },
-  important: { color: colors.important[mode], fontWeight: 'bold' },
+  '.style .token.string': { color: prismColors['.style .token.string'][mode] },
+  variable: { color: prismColors.variable[mode] },
+  atrule: { color: prismColors.atrule[mode] },
+  'attr-value': { color: prismColors['attr-value'][mode] },
+  regex: { color: prismColors.regex[mode] },
+  important: { color: prismColors.important[mode], fontWeight: 'bold' },
   bold: { fontWeight: 'bold' },
   italic: { fontStyle: 'italic' },
 });
 
-export const prism = { dark: themeMode('dark'), light: themeMode('light') };
+export const buildPrism = (tokens) => {
+  const prismColors = createPrismColors(tokens);
+
+  return {
+    dark: themeMode('dark', prismColors),
+    light: themeMode('light', prismColors),
+  };
+};
+
+export const prism = buildPrism({
+  primitives: localPrimitives,
+  dark: localDark,
+  light: localLight,
+  components: localComponents,
+});


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?

Closes https://github.com/grommet/hpe-design-system/issues/6375

This pull request refactors the color and Prism theme generation logic to make it more dynamic and testable. Instead of relying on static, precomputed color and Prism theme objects, the code now provides builder functions (`buildColors`, `buildPrism`) that generate themes from a given set of design tokens. This allows for easier customization and testing, and ensures that theme changes are immediately reflected. The update includes new unit tests for these builder functions and updates imports and exports accordingly.

**Dynamic Theme Generation:**
- Refactored `colors.js` and `prism.js` to export `buildColors` and `buildPrism` functions that generate color and Prism theme objects from provided tokens, rather than using static precomputed objects. The prebuilt `colors` and `prism` exports are now generated by calling these functions with the default tokens. [[1]](diffhunk://#diff-ab0626eee0e2c9b549d80b72acb6def5d56e42f0254ece550ca79e83d5b131ccL27-R44) [[2]](diffhunk://#diff-ab0626eee0e2c9b549d80b72acb6def5d56e42f0254ece550ca79e83d5b131ccR239-R247) [[3]](diffhunk://#diff-f808ecd94c63c3e8a5bb84a3a332883ab7a5b08f786082cc2109467ba44ce328L4-R16) [[4]](diffhunk://#diff-f808ecd94c63c3e8a5bb84a3a332883ab7a5b08f786082cc2109467ba44ce328L152-R213)

**Improved Testability:**
- Added new unit tests in `colors.test.js` and `prism.test.js` to verify that the builder functions produce the correct output and respond to changes in the input tokens. [[1]](diffhunk://#diff-831de40cc279e190296b6a892e63486bd099f7078d6e4011c0d9911e2703f643R1-R41) [[2]](diffhunk://#diff-29b3e933e997a51b12c774dbd794127679894d1540de88125fc11bb7aabf062cR1-R47)

**API and Import/Export Updates:**
- Updated imports and exports throughout the theme files to use the new builder functions, ensuring that themes are built dynamically and consistently across the codebase. [[1]](diffhunk://#diff-ab0626eee0e2c9b549d80b72acb6def5d56e42f0254ece550ca79e83d5b131ccL1-R6) [[2]](diffhunk://#diff-0ea9b1217744b978fa7c1ac3ab44c113973e55fbe073fc22011857993680bb57R62-R66) [[3]](diffhunk://#diff-e0d9ecfbe3ab2afa7ef7440f3999a839c2b90b1bce1be31c702d6e0d927879c1L6-R7)

**Internal Logic Improvements:**
- Refactored helper functions (such as `swapped`) to accept theme objects as parameters, making them more flexible and testable. [[1]](diffhunk://#diff-ab0626eee0e2c9b549d80b72acb6def5d56e42f0254ece550ca79e83d5b131ccL27-R44) [[2]](diffhunk://#diff-ab0626eee0e2c9b549d80b72acb6def5d56e42f0254ece550ca79e83d5b131ccL65-R97)

These changes make the theming system more robust, maintainable, and adaptable to future updates in design tokens.

#### What testing has been done on this PR?

Added unit tests

#### Any background context you want to provide?

We want to be able to test local token value changes in hpe-design-system, however we could not do that for color tokens because the color object was only built from imports from published package.

#### What are the relevant issues?

https://github.com/grommet/hpe-design-system/issues/6375

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?

#### How should this PR be communicated in the release notes?
