### PR TITLE
fix text color for calendar selected remove extend

### DIFF
--- a/src/js/__tests__/integration/__snapshots__/hpe.snapshots.test.js.snap
+++ b/src/js/__tests__/integration/__snapshots__/hpe.snapshots.test.js.snap
@@ -913,7 +913,6 @@ exports[`Theme snapshot groups matches content snapshot 1`] = `
       "adjacent": {
         "color": "text-weak",
       },
-      "extend": [Function],
       "hover": {
         "background": "background-hover",
         "color": "text-strong",
@@ -936,6 +935,10 @@ exports[`Theme snapshot groups matches content snapshot 1`] = `
         },
         "hover": {
           "background": "background-selected-primary-strong-hover",
+          "color": {
+            "dark": "#ffffff",
+            "light": "#292d3a",
+          },
         },
       },
     },

--- a/src/js/themes/content.js
+++ b/src/js/themes/content.js
@@ -1,7 +1,14 @@
 export const buildContentTheme = (tokens, context) => {
-  const { components, global } = tokens;
+  const { components, global, light, dark } = tokens;
   const { baseSpacing, mediumIconOnlyPad } = context;
   const { Down, Left, Pin, Right, Subtract, Up } = context.icons;
+
+  // Pulling the raw values directly from the token files gives us the color
+  // exactly as authored.
+  const textOnSelectedPrimaryStrong = {
+    light: light.hpe.color.text.onSelectedPrimaryStrong,
+    dark: dark.hpe.color.text.onSelectedPrimaryStrong,
+  };
 
   return {
     avatar: {
@@ -37,7 +44,13 @@ export const buildContentTheme = (tokens, context) => {
         selected: {
           background: 'background-selected-primary-strong',
           color: 'text-onSelectedPrimaryStrong',
-          hover: { background: 'background-selected-primary-strong-hover' },
+          hover: {
+            background: 'background-selected-primary-strong-hover',
+            color: {
+              dark: textOnSelectedPrimaryStrong.light,
+              light: textOnSelectedPrimaryStrong.dark,
+            },
+          },
           font: { weight: global.hpe.fontWeight.medium },
         },
         inRange: {
@@ -48,14 +61,6 @@ export const buildContentTheme = (tokens, context) => {
           },
           font: { weight: global.hpe.fontWeight.medium },
         },
-        extend: ({ isSelected, theme }) =>
-          isSelected
-            ? `color: ${
-                theme.global.colors['text-onSelectedPrimaryStrong'][
-                  theme.dark ? 'light' : 'dark'
-                ]
-              };`
-            : '',
       },
       range: { background: 'background-selected-primary' },
       icons: {


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Fixes the text color for selected calendar days as we as on hover. Previously, `calendar.day` used an `extend` function to invert the `text-onSelectedPrimaryStrong` color based on light/dark theme state. This was not working or coming through correctly.

#### What testing has been done on this PR?
verified on the NEW storybook 🥳 

old screen shot 
light mode:

<img width="829" height="525" alt="Screenshot 2026-07-24 at 3 57 33 PM" src="https://github.com/user-attachments/assets/352d7afa-724e-44b2-aaba-3644793d8f2c" />

dark mdoe: 

<img width="420" height="460" alt="Screenshot 2026-07-24 at 3 57 58 PM" src="https://github.com/user-attachments/assets/eef9b3f3-7d4c-43ea-a6e7-7a1ae1492fd8" />


with new changes 

light mode: 

<img width="499" height="435" alt="Screenshot 2026-07-24 at 3 58 16 PM" src="https://github.com/user-attachments/assets/7c502842-4f45-4e5f-88aa-0c1bdb4892ae" />

dark mode: 

<img width="761" height="690" alt="Screenshot 2026-07-24 at 3 58 41 PM" src="https://github.com/user-attachments/assets/7efd37d9-c284-4755-abc5-ca1e1fcf0cc3" />

#### Any background context you want to provide?
The prior `extend` approach reached into `theme.global.colors` and `theme.dark` directly, which is harder to maintain and reason about. Sourcing the color values from `light.hpe.color.text.onSelectedPrimaryStrong` / `dark.hpe.color.text.onSelectedPrimaryStrong` keeps the theme declarative and consistent with how other tokens are built in `content.js`.
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
yes a fix
#### How should this PR be communicated in the release notes?
Fix: corrected text color on hover for selected calendar days to maintain proper contrast in both light and dark themes.