### PR TITLE
Point to token values for TimeInput theme

### DIFF
--- a/src/js/__tests__/unit/utils.test.js
+++ b/src/js/__tests__/unit/utils.test.js
@@ -4,6 +4,7 @@ import {
   deepFreeze,
   getHeadingSize,
   getTextSize,
+  getTokenColorPair,
   getThemeColor,
   isObject,
 } from '../../themes/utils';
@@ -88,6 +89,20 @@ describe('Pure utility functions', () => {
     it('should return original color token when key is missing', () => {
       const theme = { dark: false, global: { colors: {} } };
       expect(getThemeColor('unknown-token', theme)).toBe('unknown-token');
+    });
+  });
+
+  describe('getTokenColorPair', () => {
+    it('should resolve raw light and dark token values from a color path', () => {
+      const tokens = {
+        dark: { hpe: { color: { background: { active: '#222222' } } } },
+        light: { hpe: { color: { background: { active: '#eeeeee' } } } },
+      };
+
+      expect(getTokenColorPair('color.background.active', tokens)).toEqual({
+        dark: '#222222',
+        light: '#eeeeee',
+      });
     });
   });
 

--- a/src/js/themes/form.js
+++ b/src/js/themes/form.js
@@ -3,10 +3,10 @@
 import React from 'react';
 import { css } from 'styled-components';
 
-import { getThemeColor } from './utils';
+import { getThemeColor, getTokenColorPair } from './utils';
 
 export const buildFormTheme = (tokens, context) => {
-  const { primitives, light, dark, large, components } = tokens;
+  const { primitives, light, large, global, components } = tokens;
   const { dimensions, option } = context;
   const {
     Alert,
@@ -27,10 +27,10 @@ export const buildFormTheme = (tokens, context) => {
   } = context.icons;
   // Pulling the raw values directly from the token files gives us the color
   // exactly as authored.
-  const textOnSelectedPrimaryStrong = {
-    light: light.hpe.color.text.onSelectedPrimaryStrong,
-    dark: dark.hpe.color.text.onSelectedPrimaryStrong,
-  };
+  const textOnSelectedPrimaryStrong = getTokenColorPair(
+    'color.text.onSelectedPrimaryStrong',
+    tokens,
+  );
 
   return {
     checkBox: {
@@ -876,29 +876,47 @@ export const buildFormTheme = (tokens, context) => {
           components.hpe.formField.default.medium.input.container.borderRadius,
       },
       button: {
-        margin: { right: '3xsmall' },
+        margin: {
+          right:
+            components.hpe.formField.default.medium.input.container.textToIconX,
+        },
       },
       active: {
-        background: 'background-active',
-        pad: '5xsmall',
+        background: getTokenColorPair('color.background.active', tokens),
+        pad: large.hpe.spacing['5xsmall'],
         indicator: {
-          color: 'focus',
+          color: getTokenColorPair('color.focus', tokens),
         },
       },
       drop: {
-        gap: '3xsmall',
-        pad: 'xsmall',
+        gap: components.hpe.select.default.medium.drop.gapY,
+        pad: large.hpe.spacing.xsmall,
         option: {
-          gap: '4xsmall',
-          pad: { vertical: '5xsmall', horizontal: 'xsmall' },
-          size: 'medium',
-          hover: {
-            background: 'background-active',
+          gap: large.hpe.spacing['4xsmall'],
+          pad: {
+            vertical: components.hpe.element.medium.paddingY,
+            horizontal:
+              components.hpe.formField.default.medium.input.group.item
+                .textToElementX,
           },
+          size: large.hpe.text.medium.fontSize,
+          hover: {
+            background: getTokenColorPair('color.background.active', tokens),
+          },
+          round: components.hpe.select.default.medium.option.borderRadius,
           selected: {
-            background: 'background-selected-primary-strong',
+            background: getTokenColorPair(
+              'color.background.selected.primary.strong',
+              tokens,
+            ),
             color: textOnSelectedPrimaryStrong,
-            hover: { background: 'background-selected-primary-strong-hover' },
+            text: { weight: global.hpe.fontWeight.medium },
+            hover: {
+              background: getTokenColorPair(
+                'color.background.selected.primary.strong.hover',
+                tokens,
+              ),
+            },
           },
         },
       },

--- a/src/js/themes/form.js
+++ b/src/js/themes/form.js
@@ -886,7 +886,12 @@ export const buildFormTheme = (tokens, context) => {
         },
       },
       drop: {
+        gap: '3xsmall',
+        pad: 'xsmall',
         option: {
+          gap: '4xsmall',
+          pad: { vertical: '5xsmall', horizontal: 'xsmall' },
+          size: 'medium',
           hover: {
             background: 'background-active',
           },

--- a/src/js/themes/utils.js
+++ b/src/js/themes/utils.js
@@ -69,6 +69,14 @@ const getThemeColor = (color, theme) =>
     ? theme.global.colors[color]
     : theme.global.colors[color]?.[theme.dark ? 'dark' : 'light'] || color;
 
+const getTokenValue = (path, tokenSet) =>
+  path.split('.').reduce((object, key) => object?.[key], tokenSet);
+
+const getTokenColorPair = (path, tokens) => ({
+  dark: getTokenValue(`hpe.${path}`, tokens.dark),
+  light: getTokenValue(`hpe.${path}`, tokens.light),
+});
+
 const getTextSize = (size) => {
   if (size === '3xlarge') return '3xl';
   if (size === '4xlarge') return '4xl';
@@ -89,5 +97,6 @@ export {
   breakpointStyle,
   getHeadingSize,
   getThemeColor,
+  getTokenColorPair,
   getTextSize,
 };

--- a/src/stories/TimeInput.stories.js
+++ b/src/stories/TimeInput.stories.js
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © Hewlett Packard Enterprise Development LP
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Box, Form, FormField, Heading, Text, TimeInput } from 'grommet';
+
+const Template = () => (
+  <Box pad="large" gap="large" width={{ max: '500px' }}>
+    <Heading margin="none">TimeInput</Heading>
+
+    <Box gap="medium">
+      <Text size="small" color="text-weak" weight="bold">
+        12-hour format
+      </Text>
+      <Form>
+        <FormField htmlFor="time-12h" label="Appointment time" name="time12h">
+          <TimeInput id="time-12h" name="time12h" format="12" />
+        </FormField>
+      </Form>
+    </Box>
+
+    <Box gap="medium">
+      <Text size="small" color="text-weak" weight="bold">
+        24-hour format
+      </Text>
+      <Form>
+        <FormField htmlFor="time-24h" label="Meeting time" name="time24h">
+          <TimeInput id="time-24h" name="time24h" format="24" />
+        </FormField>
+      </Form>
+    </Box>
+
+    <Box gap="medium">
+      <Text size="small" color="text-weak" weight="bold">
+        With seconds
+      </Text>
+      <Form>
+        <FormField htmlFor="time-seconds" label="Duration" name="timeSeconds">
+          <TimeInput
+            id="time-seconds"
+            name="timeSeconds"
+            format="24"
+            showSeconds
+          />
+        </FormField>
+      </Form>
+    </Box>
+
+    <Box gap="medium">
+      <Text size="small" color="text-weak" weight="bold">
+        Disabled
+      </Text>
+      <Form>
+        <FormField htmlFor="time-disabled" label="Disabled" name="timeDisabled">
+          <TimeInput
+            id="time-disabled"
+            name="timeDisabled"
+            format="12"
+            value="02:30 PM"
+            disabled
+          />
+        </FormField>
+      </Form>
+    </Box>
+
+    <Box gap="medium">
+      <Text size="small" color="text-weak" weight="bold">
+        Read only
+      </Text>
+      <Form>
+        <FormField
+          htmlFor="time-readonly"
+          label="Read only"
+          name="timeReadonly"
+        >
+          <TimeInput
+            id="time-readonly"
+            name="timeReadonly"
+            format="12"
+            value="09:00 AM"
+            readOnly
+          />
+        </FormField>
+      </Form>
+    </Box>
+  </Box>
+);
+
+const meta = {
+  title: 'Theme/TimeInput',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+export const Overview = {
+  render: Template,
+};


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
This PR aligns the theme in code with the TimeInput Figma 
https://www.figma.com/design/PWNGorPUwzzjj7exRUV808/branch/wOrLVmWRIFlxSjLzz7mYTP/-6285---TimeInput?timeline=keyframe&node-id=2909-5939&t=cFhaW7aotBWnPMaS-0 see the code comparison section 
#### What testing has been done on this PR?
locally 
#### Any background context you want to provide?
This needs grommet changes which are here
https://github.com/grommet/grommet/pull/8091
#### What are the relevant issues?

#### Screenshots (if appropriate)

#### Is this change backward compatible or could it be a breaking change for the official HPE theme?
backward compatible since in beta
#### How should this PR be communicated in the release notes?
